### PR TITLE
Benchmarks

### DIFF
--- a/JobScheduler.Benchmarks/Benchmark.cs
+++ b/JobScheduler.Benchmarks/Benchmark.cs
@@ -1,0 +1,10 @@
+namespace Arch.Benchmarks;
+
+public class Benchmark
+{
+    private static void Main(string[] args)
+    {
+        // Use: dotnet run -c Release --framework net7.0 -- --job short --filter *BenchmarkClass1*
+        BenchmarkSwitcher.FromAssembly(typeof(Benchmark).Assembly).Run(args);
+    }
+}

--- a/JobScheduler.Benchmarks/JobScheduler.Benchmarks.csproj
+++ b/JobScheduler.Benchmarks/JobScheduler.Benchmarks.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Nullable>enable</Nullable>
+    <Configurations>Debug;Release;</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Runtime.CompilerServices" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+
+    <Using Include="BenchmarkDotNet.Attributes" />
+    <Using Include="BenchmarkDotNet.Columns" />
+    <Using Include="BenchmarkDotNet.Configs" />
+    <Using Include="BenchmarkDotNet.Diagnosers" />
+    <Using Include="BenchmarkDotNet.Engines" />
+    <Using Include="BenchmarkDotNet.Loggers" />
+    <Using Include="BenchmarkDotNet.Running" />
+    <Using Include="BenchmarkDotNet.Validators" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JobScheduler\JobScheduler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
@@ -1,0 +1,83 @@
+﻿namespace JobScheduler.Benchmarks;
+
+/// <summary>
+/// Benchmark adding a ton of jobs to the queue, flushing, and then completing them.
+/// </summary>
+[MemoryDiagnoser]
+public class ManyJobsBenchmark
+{
+    private JobScheduler Scheduler = null!;
+
+    /// <summary>
+    /// The thread count tested
+    /// </summary>
+    [Params(0)] public int Threads = 0; 
+    
+
+    /// <summary>
+    /// Whether the benchmark should do a dry run before starting the benchmark, to fill up any data structures that might allocate
+    /// on frame 1.
+    /// </summary>
+    [Params(true, false)] public bool SetupJobsFirst;
+
+    /// <summary>
+    /// The amount of jobs to run.
+    /// </summary>
+    [Params(10, 100, 1000000)] public int JobCount;
+
+    JobHandle[] Handles = null!;
+    private class EmptyJob : IJob
+    {
+        public void Execute() { }
+    }
+
+    private static IJob Empty => new EmptyJob();
+
+    [IterationSetup]
+    public void Setup()
+    {
+        Scheduler = new(nameof(ManyJobsBenchmark), Threads);
+        Handles = new JobHandle[JobCount];
+
+        if (SetupJobsFirst)
+        {
+            for (int i = 0; i < JobCount; i++)
+            {
+                Handles[i] = Scheduler.Schedule(Empty);
+            }
+            Scheduler.Flush();
+            for (int i = 0; i < JobCount; i++)
+            {
+                Handles[i].Complete();
+            }
+            for (int i = 0; i < JobCount; i++)
+            {
+                Handles[i].Return();
+            }
+        }
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        Scheduler.Dispose();
+    }
+
+    [Benchmark]
+    public void TestParallel()
+    {
+        for (int i = 0; i < JobCount; i++)
+        {
+            Handles[i] = Scheduler.Schedule(Empty);
+        }
+        Scheduler.Flush();
+        for (int i = 0; i < JobCount; i++)
+        {
+            Handles[i].Complete();
+        }
+        for (int i = 0; i < JobCount; i++)
+        {
+            Handles[i].Return();
+        }
+    }
+}

--- a/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
@@ -11,19 +11,23 @@ public class ManyJobsBenchmark
     /// <summary>
     /// The thread count tested
     /// </summary>
-    [Params(0)] public int Threads = 0; 
-    
+    [Params(0)] public int Threads = 0;     
 
     /// <summary>
     /// Whether the benchmark should do a dry run before starting the benchmark, to fill up any data structures that might allocate
     /// on frame 1.
     /// </summary>
-    [Params(true, false)] public bool SetupJobsFirst;
+    [Params(true)] public bool ExcludeFirstWave;
 
     /// <summary>
-    /// The amount of jobs to run.
+    /// The maximum amount of concurrent jobs active at one time.
     /// </summary>
-    [Params(10, 100, 1000000)] public int JobCount;
+    [Params(128)] public int ConcurrentJobs;
+
+    /// <summary>
+    /// How many sequences of <see cref="ConcurrentJobs"/> to run.
+    /// </summary>
+    [Params(10240)] public int Waves;
 
     JobHandle[] Handles = null!;
     private class EmptyJob : IJob
@@ -31,26 +35,27 @@ public class ManyJobsBenchmark
         public void Execute() { }
     }
 
-    private static IJob Empty => new EmptyJob();
+    private readonly static EmptyJob Empty = new();
 
     [IterationSetup]
     public void Setup()
     {
         Scheduler = new(nameof(ManyJobsBenchmark), Threads);
-        Handles = new JobHandle[JobCount];
+        Handles = new JobHandle[ConcurrentJobs];
 
-        if (SetupJobsFirst)
+        if (ExcludeFirstWave)
         {
-            for (int i = 0; i < JobCount; i++)
+            Waves--;
+            for (int i = 0; i < ConcurrentJobs; i++)
             {
                 Handles[i] = Scheduler.Schedule(Empty);
             }
             Scheduler.Flush();
-            for (int i = 0; i < JobCount; i++)
+            for (int i = 0; i < ConcurrentJobs; i++)
             {
                 Handles[i].Complete();
             }
-            for (int i = 0; i < JobCount; i++)
+            for (int i = 0; i < ConcurrentJobs; i++)
             {
                 Handles[i].Return();
             }
@@ -66,18 +71,21 @@ public class ManyJobsBenchmark
     [Benchmark]
     public void BenchmarkParallel()
     {
-        for (int i = 0; i < JobCount; i++)
+        for (int w = 0; w < Waves; w++)
         {
-            Handles[i] = Scheduler.Schedule(Empty);
-        }
-        Scheduler.Flush();
-        for (int i = 0; i < JobCount; i++)
-        {
-            Handles[i].Complete();
-        }
-        for (int i = 0; i < JobCount; i++)
-        {
-            Handles[i].Return();
+            for (int i = 0; i < ConcurrentJobs; i++)
+            {
+                Handles[i] = Scheduler.Schedule(Empty);
+            }
+            Scheduler.Flush();
+            for (int i = 0; i < ConcurrentJobs; i++)
+            {
+                Handles[i].Complete();
+            }
+            for (int i = 0; i < ConcurrentJobs; i++)
+            {
+                Handles[i].Return();
+            }
         }
     }
 }

--- a/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
@@ -64,7 +64,7 @@ public class ManyJobsBenchmark
     }
 
     [Benchmark]
-    public void TestParallel()
+    public void BenchmarkParallel()
     {
         for (int i = 0; i < JobCount; i++)
         {

--- a/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
@@ -11,7 +11,7 @@ public class ManyJobsBenchmark
     /// <summary>
     /// The thread count tested
     /// </summary>
-    [Params(0)] public int Threads = 0;     
+    [Params(0)] public int Threads = 0;
 
     /// <summary>
     /// Whether the benchmark should do a dry run before starting the benchmark, to fill up any data structures that might allocate
@@ -22,7 +22,7 @@ public class ManyJobsBenchmark
     /// <summary>
     /// The maximum amount of concurrent jobs active at one time.
     /// </summary>
-    [Params(128)] public int ConcurrentJobs;
+    [Params(32, 128)] public int ConcurrentJobs;
 
     /// <summary>
     /// How many sequences of <see cref="ConcurrentJobs"/> to run.
@@ -84,6 +84,21 @@ public class ManyJobsBenchmark
             }
             for (int i = 0; i < ConcurrentJobs; i++)
             {
+                Handles[i].Return();
+            }
+        }
+    }
+
+    [Benchmark]
+    public void BenchmarkSequential()
+    {
+        for (int w = 0; w < Waves; w++)
+        {
+            for (int i = 0; i < ConcurrentJobs; i++)
+            {
+                Handles[i] = Scheduler.Schedule(Empty);
+                Scheduler.Flush();
+                Handles[i].Complete();
                 Handles[i].Return();
             }
         }

--- a/JobScheduler.Benchmarks/QueueBenchmark.cs
+++ b/JobScheduler.Benchmarks/QueueBenchmark.cs
@@ -1,0 +1,64 @@
+﻿namespace JobScheduler.Benchmarks;
+
+[MemoryDiagnoser]
+public class QueueBenchmark
+{
+    /// <summary>
+    /// The amount of items in a Queue.
+    /// </summary>
+    [Params(10, 100, 5000000)] public int QueueCapacity;
+
+    Queue<int> Queue = null!;
+    ConcurrentQueue<int> ConcurrentQueue = null!;
+
+    [IterationSetup]
+    public void Setup()
+    {
+        Queue = new Queue<int>();
+        ConcurrentQueue = new ConcurrentQueue<int>();
+
+        for (int i = 0; i < QueueCapacity; i++)
+        {
+            ConcurrentQueue.Enqueue(0);
+            Queue.Enqueue(0);
+        }
+        ConcurrentQueue.Clear();
+        Queue.Clear();
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        ConcurrentQueue = null!;
+        Queue = null!;
+    }
+
+    private static int Nothing = 0;
+
+    [Benchmark]
+    public void TestEmptyBenchmark()
+    {
+        for (int i = 0; i < QueueCapacity; i++)
+        {
+            Nothing++;
+        }
+    }
+
+    [Benchmark]
+    public void TestConcurrentQueue()
+    {
+        for (int i = 0; i < QueueCapacity; i++)
+        {
+            ConcurrentQueue.Enqueue(0);
+        }
+    }
+
+    [Benchmark]
+    public void TestQueue()
+    {
+        for (int i = 0; i < QueueCapacity; i++)
+        {
+            Queue.Enqueue(0);
+        }
+    }
+}

--- a/JobScheduler.Benchmarks/QueueBenchmark.cs
+++ b/JobScheduler.Benchmarks/QueueBenchmark.cs
@@ -33,19 +33,19 @@ public class QueueBenchmark
         Queue = null!;
     }
 
-    private static int Nothing = 0;
+    private static int _nothing = 0;
 
     [Benchmark]
-    public void TestEmptyBenchmark()
+    public void BenchmarkEmpty()
     {
         for (int i = 0; i < QueueCapacity; i++)
         {
-            Nothing++;
+            _nothing++;
         }
     }
 
     [Benchmark]
-    public void TestConcurrentQueue()
+    public void BenchmarkConcurrentQueue()
     {
         for (int i = 0; i < QueueCapacity; i++)
         {
@@ -54,7 +54,7 @@ public class QueueBenchmark
     }
 
     [Benchmark]
-    public void TestQueue()
+    public void BenchmarkQueue()
     {
         for (int i = 0; i < QueueCapacity; i++)
         {

--- a/JobScheduler.Benchmarks/QueueBenchmark.cs
+++ b/JobScheduler.Benchmarks/QueueBenchmark.cs
@@ -6,7 +6,12 @@ public class QueueBenchmark
     /// <summary>
     /// The amount of items in a Queue.
     /// </summary>
-    [Params(10, 100, 5000000)] public int QueueCapacity;
+    [Params(1, 32, 64, 128, 256, 512)] public int QueueCapacity;
+
+    /// <summary>
+    /// The amount of times to repeat the add/clear process
+    /// </summary>
+    [Params(32)] public int Reps;
 
     Queue<int> Queue = null!;
     ConcurrentQueue<int> ConcurrentQueue = null!;
@@ -33,32 +38,42 @@ public class QueueBenchmark
         Queue = null!;
     }
 
-    private static int _nothing = 0;
-
     [Benchmark]
-    public void BenchmarkEmpty()
+    public void BenchmarkConcurrentQueue()
     {
-        for (int i = 0; i < QueueCapacity; i++)
+        for (int r = 0; r < Reps; r++)
         {
-            _nothing++;
+            for (int i = 0; i < QueueCapacity; i++)
+            {
+                ConcurrentQueue.Enqueue(0);
+            }
+            ConcurrentQueue.Clear();
         }
     }
 
     [Benchmark]
-    public void BenchmarkConcurrentQueue()
+    public void BenchmarkConcurrentQueueWithDequeue()
     {
-        for (int i = 0; i < QueueCapacity; i++)
+        for (int r = 0; r < Reps; r++)
         {
-            ConcurrentQueue.Enqueue(0);
+            for (int i = 0; i < QueueCapacity; i++)
+            {
+                ConcurrentQueue.Enqueue(0);
+            }
+            while (ConcurrentQueue.TryDequeue(out var _)) { }
         }
     }
 
     [Benchmark]
     public void BenchmarkQueue()
     {
-        for (int i = 0; i < QueueCapacity; i++)
+        for (int r = 0; r < Reps; r++)
         {
-            Queue.Enqueue(0);
+            for (int i = 0; i < QueueCapacity; i++)
+            {
+                Queue.Enqueue(0);
+            }
+            Queue.Clear();
         }
     }
 }

--- a/JobScheduler.sln
+++ b/JobScheduler.sln
@@ -1,8 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JobScheduler", "JobScheduler\JobScheduler.csproj", "{96AB1B0E-2501-4972-BECA-690878DB5852}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler", "JobScheduler\JobScheduler.csproj", "{96AB1B0E-2501-4972-BECA-690878DB5852}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JobScheduler.Test", "JobScheduler.Test\JobScheduler.Test.csproj", "{22CA05F3-3921-4DEE-BC02-392BBC7F885C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler.Test", "JobScheduler.Test\JobScheduler.Test.csproj", "{22CA05F3-3921-4DEE-BC02-392BBC7F885C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler.Benchmarks", "JobScheduler.Benchmarks\JobScheduler.Benchmarks.csproj", "{1C11086C-D170-41A9-BDC3-76F4D617A607}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +23,12 @@ Global
 		{22CA05F3-3921-4DEE-BC02-392BBC7F885C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{22CA05F3-3921-4DEE-BC02-392BBC7F885C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22CA05F3-3921-4DEE-BC02-392BBC7F885C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C11086C-D170-41A9-BDC3-76F4D617A607}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C11086C-D170-41A9-BDC3-76F4D617A607}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C11086C-D170-41A9-BDC3-76F4D617A607}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C11086C-D170-41A9-BDC3-76F4D617A607}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adds a benchmark framework with an initial benchmark, based of Arch's solution.

Current results as of this PR: 
```
BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 10 (10.0.19045.3448/22H2/2022Update)
AMD Ryzen 7 5800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 7.0.401
  [Host]     : .NET 7.0.11 (7.0.1123.42427), X64 RyuJIT AVX2
  Job-ZPCEAS : .NET 7.0.11 (7.0.1123.42427), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1  
```
| Method              | Threads | ExcludeFirstWave | ConcurrentJobs | Waves | Mean        | Error    | StdDev   | Gen0      | Gen1      | Allocated  |
|-------------------- |-------- |----------------- |--------------- |------ |------------:|---------:|---------:|----------:|----------:|-----------:|
| **BenchmarkParallel**   | **0**       | **True**             | **32**             | **10240** |    **343.2 ms** |  **4.13 ms** |  **3.66 ms** |         **-** |         **-** |      **600 B** |
| BenchmarkSequential | 0       | True             | 32             | 10240 |  3,732.7 ms | 17.31 ms | 16.19 ms |         - |         - |      600 B |
| **BenchmarkParallel**   | **0**       | **True**             | **128**            | **10240** |  **1,344.9 ms** | **11.85 ms** | **11.09 ms** | **1000.0000** | **1000.0000** | **54921816 B** |
| BenchmarkSequential | 0       | True             | 128            | 10240 | 14,916.6 ms | 97.26 ms | 81.22 ms |         - |         - |      600 B |


This will be easier to address prior to #7.
