### PR TITLE
Consistent allocation

### DIFF
--- a/JobScheduler.Benchmarks/MaxConcurrentJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/MaxConcurrentJobsBenchmark.cs
@@ -1,0 +1,79 @@
+﻿namespace JobScheduler.Benchmarks;
+
+/// <summary>
+/// Benchmark the overhead of increasing the <see cref="JobScheduler.Config.MaxExpectedConcurrentJobs"/> without changing the total amount of jobs run.
+/// </summary>
+[MemoryDiagnoser]
+public class MaxConcurrentJobsBenchmark
+{
+    private JobScheduler Scheduler = null!;
+
+    /// <summary>
+    /// The thread count tested
+    /// </summary>
+    [Params(0)] public int Threads = 0;
+
+    /// <summary>
+    /// The amount of total jobs to schedule over the course of the test.
+    /// </summary>
+    [Params(1024 * 32)] public int TotalJobs;
+
+    /// <summary>
+    /// The <see cref="JobScheduler.Config.MaxExpectedConcurrentJobs"/> value. If this is less than <see cref="ConcurrentJobs"/> on a given benchmark,
+    /// the benchmark is expected to allocate.
+    /// </summary>
+    [Params(32, 4096)] public int MaxConcurrentJobs;
+
+    Queue<JobHandle> Handles = null!;
+    private class EmptyJob : IJob
+    {
+        public void Execute() { }
+    }
+
+    private readonly static EmptyJob Empty = new();
+
+    [IterationSetup]
+    public void Setup()
+    {
+        var config = new JobScheduler.Config
+        {
+            MaxExpectedConcurrentJobs = MaxConcurrentJobs,
+            StrictAllocationMode = true,
+            ThreadPrefixName = nameof(MaxConcurrentJobsBenchmark),
+            ThreadCount = Threads
+        };
+        Scheduler = new(config);
+        Handles = new Queue<JobHandle>(MaxConcurrentJobs);
+    }
+
+    [IterationCleanup]
+    public void Cleanup()
+    {
+        Scheduler.Dispose();
+    }
+
+    [Benchmark]
+    public void BenchmarkDependancies()
+    {
+        int jobsSoFar = 0;
+
+        // schedule some starter jobs; should have negligible impact on total performance even with varying MaxConcurrentJobs as long as TotalJobs >>> MaxConcurrentJobs
+        for (int i = 0; i < MaxConcurrentJobs; i++)
+        {
+            Handles.Enqueue(Scheduler.Schedule(Empty));
+            jobsSoFar++;
+        }
+        Scheduler.Flush();
+
+        // keep going up until the total job limit of jobs processed
+        while (jobsSoFar <= TotalJobs)
+        {
+            // complete the last-entered job; probably complete by now
+            Handles.Dequeue().Complete();
+            // schedule a new one to fill the gap
+            Handles.Enqueue(Scheduler.Schedule(Empty));
+            Scheduler.Flush();
+            jobsSoFar++;
+        }
+    }
+}

--- a/JobScheduler.Test/CompleteTests.cs
+++ b/JobScheduler.Test/CompleteTests.cs
@@ -6,6 +6,8 @@ internal class CompleteTests : SchedulerTestFixture
 {
     public CompleteTests(int threads) : base(threads) { }
 
+    protected override bool StrictAllocationMode => false;
+
     [Test]
     public void OneJobCompletes()
     {

--- a/JobScheduler.Test/QueueAllocationTests.cs
+++ b/JobScheduler.Test/QueueAllocationTests.cs
@@ -1,0 +1,59 @@
+﻿using JobScheduler.Test.Utils.CustomConstraints;
+using System.Collections.Concurrent;
+
+namespace JobScheduler.Test;
+
+[TestFixture]
+internal class QueueAllocationTests
+{
+    private struct BigStruct
+    {
+#pragma warning disable CS0649 // Field 'QueueAllocationTests.BigStruct.l1' is never assigned to, and will always have its default value 0
+        internal long l1;
+        internal long l2;
+        internal long l3;
+        internal long l4;
+        internal long l5;
+        internal long l6;
+        internal long l7;
+        internal long l8;
+        internal long l9;
+        internal long l10;
+        internal long l11;
+        internal long l12;
+        internal long l13;
+        internal long l14;
+        internal long l15;
+        internal long l16;
+#pragma warning restore CS0649 // Field 'QueueAllocationTests.BigStruct.l1' is never assigned to, and will always have its default value 0
+    }
+
+    // test 
+    [Test]
+    [TestCase(32)]
+    [TestCase(128)]
+    public void ConcurrentQueueAllocationCache(int n)
+    {
+        Queue<BigStruct> cacheQueue = new();
+
+        // cache
+        for (int i = 0; i < n; i++)
+        {
+            cacheQueue.Enqueue(default);
+        }
+
+        ConcurrentQueue<BigStruct> queue = new(cacheQueue);
+
+        while (!queue.IsEmpty) queue.TryDequeue(out var _);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.That(() => { queue.Enqueue(default); }, Is.Not.AllocatingMemory());
+        }
+
+        while (!queue.IsEmpty)
+        {
+            Assert.That(() => { queue.TryDequeue(out var _); }, Is.Not.AllocatingMemory());
+        }
+    }
+}

--- a/JobScheduler.Test/StressTests.cs
+++ b/JobScheduler.Test/StressTests.cs
@@ -1,15 +1,28 @@
 ﻿using JobScheduler.Test.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace JobScheduler.Test;
-
+[TestFixture(0, 32)]
+[TestFixture(1, 32)]
+[TestFixture(2, 32)]
+[TestFixture(4, 32)]
+[TestFixture(8, 32)]
+[TestFixture(16, 32)]
+[TestFixture(0, 2048)]
+[TestFixture(1, 2048)]
+[TestFixture(2, 2048)]
+[TestFixture(4, 2048)]
+[TestFixture(8, 2048)]
+[TestFixture(16, 2048)]
 internal class StressTests : SchedulerTestFixture
 {
-    public StressTests(int threads) : base(threads) { }
+    public StressTests(int threads, int maxJobs) : base(threads)
+    {
+        MaxExpectedConcurrentJobs = maxJobs;
+    }
+
+    protected override bool StrictAllocationMode => false;
+
+    protected override int MaxExpectedConcurrentJobs { get; }
 
     [Test]
     [TestCase(1000, 10, true, false)]

--- a/JobScheduler.Test/Utils/SchedulerTestFixture.cs
+++ b/JobScheduler.Test/Utils/SchedulerTestFixture.cs
@@ -16,6 +16,10 @@ internal class SchedulerTestFixture
 
     protected bool SuppressDispose { get; set; } = false;
 
+    // override to change values for fixture
+    protected virtual bool StrictAllocationMode { get; } = true;
+    protected virtual int MaxExpectedConcurrentJobs { get; } = 32;
+
     public SchedulerTestFixture(int threads)
     {
         ThreadCount = threads;
@@ -24,7 +28,12 @@ internal class SchedulerTestFixture
     [SetUp]
     public void Setup()
     {
-        Scheduler = new JobScheduler("Test", ThreadCount);
+        Scheduler = new JobScheduler(new() {
+            ThreadPrefixName = "Test",
+            ThreadCount = ThreadCount,
+            MaxExpectedConcurrentJobs = MaxExpectedConcurrentJobs,
+            StrictAllocationMode = StrictAllocationMode
+        });
     }
 
     [TearDown]

--- a/JobScheduler/JobHandle.cs
+++ b/JobScheduler/JobHandle.cs
@@ -85,7 +85,7 @@ public readonly struct JobHandle
     /// <remarks>This is equivalent to calling <see cref="Complete()"/> on each <see cref="JobHandle"/> individually.</remarks>
     /// <param name="handles">The handles to complete.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void CompleteAll(IList<JobHandle> handles)
+    public static void CompleteAll(List<JobHandle> handles)
     {
         foreach (var handle in handles) handle.Complete();
     }

--- a/JobScheduler/JobPool.cs
+++ b/JobScheduler/JobPool.cs
@@ -64,18 +64,7 @@ internal class JobPool
     /// <summary>
     /// The amount of concurrent jobs currently in the <see cref="JobPool"/>.
     /// </summary>
-    public int JobCount
-    {
-        get
-        {
-            int jobs = 0;
-            foreach (var job in _jobs)
-            {
-                if (job.HasValue) jobs++;
-            }
-            return jobs;
-        }
-    }
+    public int JobCount { get; private set; }
 
     public JobPool(int capacity)
     {
@@ -113,6 +102,7 @@ internal class JobPool
         }
         
         _jobs[id.Id] = job;
+        JobCount++;
         return id;
     }
     
@@ -127,6 +117,7 @@ internal class JobPool
 
         var job = _jobs[jobId.Id]!.Value;
         _jobs[jobId.Id] = null;
+        JobCount--;
         jobId.Version++;
         
         _recycledIds.Enqueue(jobId);

--- a/JobScheduler/JobPool.cs
+++ b/JobScheduler/JobPool.cs
@@ -81,17 +81,12 @@ internal class JobPool
     /// <returns>The <see cref="JobId"/> of the created job</returns>
     public JobId Schedule()
     {
-        JobId id;
-        if (_recycledIds.TryDequeue(out var recycledId))
-        {
-            id = recycledId;
-        }
-        else
+        if (!_recycledIds.TryDequeue(out JobId id))
         {
             id = new JobId(_nextId, 1);
             _nextId++;
         }
-        
+
         var job = new Job(id, ManualResetEventPool.Get());
         Debug.Assert(job.WaitHandle is not null);
         job.WaitHandle.Reset(); // must reset when acquiring

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -10,15 +10,52 @@ namespace JobScheduler;
 public class JobScheduler : IDisposable
 {
     /// <summary>
-    /// Tracks which thread the JobScheduler was constructed on
+    /// Contains configuration settings for <see cref="JobScheduler"/>.
     /// </summary>
-    private int MainThreadID { get; }
+    public struct Config
+    {
+        /// <summary>
+        /// Create a new <see cref="Config"/> for a <see cref="JobScheduler"/> with all default settings.
+        /// </summary>
+        public Config() { }
 
-    // Tracks how many threads are active; interlocked
-    private int _threadsActive = 0;
+        /// <summary>
+        /// Defines the maximum expected number of concurrent jobs. Increasing this number will allow more jobs to be scheduled
+        /// without spontaneous allocation, but will increase total memory consumption and decrease performance.
+        /// If unset, the default is <c>32</c>
+        /// </summary>
+        public int MaxExpectedConcurrentJobs { get; set; } = 32;
 
-    // internally visible for testing
-    internal int ThreadsActive => _threadsActive;
+        /// <summary>
+        /// Whether to use Strict Allocation Mode for this <see cref="JobScheduler"/>. If an allocation might occur, the JobScheduler
+        /// will throw a <see cref="MaximumConcurrentJobCountExceededException"/>.
+        /// Not recommended for production environments (spontaneous allocation is probably usually better than crashing the program).
+        /// </summary>
+        public bool StrictAllocationMode { get; set; } = false;
+
+        /// <summary>
+        /// The process name to use for spawned child threads. By default, set to the current domain's <see cref="AppDomain.FriendlyName"/>.
+        /// Thread will be named "prefix0" for the first thread, "prefix1" for the second thread, etc.
+        /// </summary>
+        public string ThreadPrefixName { get; set; } = AppDomain.CurrentDomain.FriendlyName;
+
+        /// <summary>
+        /// The amount of worker threads to use. By default, set to <see cref="Environment.ProcessorCount"/>, the amount of hardware processors 
+        /// available on the system.
+        /// </summary>
+        public int ThreadCount { get; set; } = Environment.ProcessorCount;
+    }
+
+    /// <summary>
+    /// Thrown when <see cref="Config.StrictAllocationMode"/> is enabled and the <see cref="JobScheduler"/> goes over its <see cref="Config.MaxExpectedConcurrentJobs"/>.
+    /// </summary>
+    public class MaximumConcurrentJobCountExceededException : Exception
+    {
+        internal MaximumConcurrentJobCountExceededException() : base($"{nameof(JobScheduler)} has gone over its {nameof(Config.MaxExpectedConcurrentJobs)} value! " +
+            $"Increase that value or disable {nameof(Config.StrictAllocationMode)} to allow spontaneous allocations.")
+        {
+        }
+    }
 
     /// <summary>
     ///     Pairs a <see cref="JobHandle"/> with its <see cref="IJob"/> and other important meta-data. 
@@ -58,27 +95,19 @@ public class JobScheduler : IDisposable
     }
 
     /// <summary>
-    /// Creates an instance of the <see cref="JobScheduler"/>
+    /// Tracks which thread the JobScheduler was constructed on
     /// </summary>
-    /// <param name="threadPrefix">The thread prefix to use. The thread will be named "prefix0" for the first thread, "prefix1" for the second thread, etc.</param>
-    /// <param name="threads">The amount of worker threads to use. If zero the scheduler will use the amount of processors available.</param>
-    public JobScheduler(string threadPrefix, int threads = 0)
-    {
-        MainThreadID = Thread.CurrentThread.ManagedThreadId;
+    private int MainThreadID { get; }
 
-        if (threads <= 0) threads = Environment.ProcessorCount;
+    // Tracks how many threads are active; interlocked
+    private int _threadsActive = 0;
 
-        // spawn all the child threads
-        for (var i = 0; i < threads; i++)
-        {
-            var thread = new Thread(() => Loop(CancellationTokenSource.Token))
-            {
-                Name = $"{threadPrefix}{i}"
-            };
-            thread.Start();
-        }
-    }
-    
+    // internally visible for testing
+    internal int ThreadsActive => _threadsActive;
+
+    private readonly bool _strictAllocationMode;
+    private readonly int _maxConcurrentJobs;
+
     // Tracks the overall state of all threads; when canceled in Dispose, all child threads are exited
     private CancellationTokenSource CancellationTokenSource { get; } = new();
 
@@ -86,14 +115,54 @@ public class JobScheduler : IDisposable
     private ManualResetEvent CheckQueueEvent { get; } = new(false);
 
     // Jobs scheduled by the client, but not yet flushed to the threads
-    private List<JobMeta> QueuedJobs { get; } = new();
+    private List<JobMeta> QueuedJobs { get; }
 
     // Jobs flushed and waiting to be picked up by worker threads
-    private ConcurrentQueue<JobMeta> Jobs { get; } = new();
+    private ConcurrentQueue<JobMeta> Jobs { get; }
 
     // Tracks each job from scheduling to completion; when they complete, however, their data is removed from the pool and recycled.
     // Note that we have to lock this, and can't use a ReaderWriterLock/ReaderWriterLockSlim because those allocate.
-    private JobPool JobPool { get; } = new();
+    private JobPool JobPool { get; }
+
+    /// <summary>
+    /// Creates an instance of the <see cref="JobScheduler"/>
+    /// </summary>
+    /// <param name="settings">The <see cref="Config"/> to use for this instance of <see cref="JobScheduler"/></param>
+    public JobScheduler(in Config settings)
+    {
+        MainThreadID = Thread.CurrentThread.ManagedThreadId;
+
+        int threads = settings.ThreadCount;
+        if (threads <= 0) threads = Environment.ProcessorCount;
+
+        _strictAllocationMode = settings.StrictAllocationMode;
+        _maxConcurrentJobs = settings.MaxExpectedConcurrentJobs;
+
+        // pre-fill all of our data structures up to the concurrent job max
+        QueuedJobs = new(settings.MaxExpectedConcurrentJobs);
+        JobPool = new(settings.MaxExpectedConcurrentJobs);
+
+        // ConcurrentQueue doesn't have a segment size constructor so we have to use a hack with the IEnumerable constructor.
+        // First, we add a bunch of dummy jobs to the old queue...
+        for (int i = 0; i < settings.MaxExpectedConcurrentJobs; i++) QueuedJobs.Add(default);
+        // ... then, we initialize the ConcurrentQueue with that collection. The segment size will be set to the count.
+        // Note that this line WILL produce garbage due to IEnumerable iteration! (always boxes multiple enumerator structs)
+        Jobs = new(QueuedJobs);
+        // Then, we dequeue everything from the ConcurrentQueue. We can't Clear() because that'll nuke the segment.
+        while (!Jobs.IsEmpty) Jobs.TryDequeue(out var _);
+        // And then normally clear the normal queue we used.
+        QueuedJobs.Clear();
+
+        // spawn all the child threads
+        for (var i = 0; i < threads; i++)
+        {
+            var thread = new Thread(() => Loop(CancellationTokenSource.Token))
+            {
+                Name = $"{settings.ThreadPrefixName}{i}"
+            };
+            thread.Start();
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsMainThread() => Thread.CurrentThread.ManagedThreadId == MainThreadID;
@@ -159,7 +228,8 @@ public class JobScheduler : IDisposable
     /// <param name="dependency">The <see cref="JobHandle"/>-Dependency.</param>
     /// <param name="dependencies">A list of additional <see cref="JobHandle"/>-Dependencies.</param>
     /// <returns>A <see cref="JobHandle"/>.</returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">If called on a different thread than the <see cref="JobScheduler"/> was constructed on</exception>
+    /// <exception cref="MaximumConcurrentJobCountExceededException">If the maximum amount of concurrent jobs is at maximum, and strict mode is enabled.</exception>
     private JobHandle Schedule(IJob? job, JobHandle? dependency = null, JobHandle[]? dependencies = null)
     {
         if (!IsMainThread())
@@ -170,6 +240,10 @@ public class JobScheduler : IDisposable
         JobId jobId;
         lock (JobPool)
         {
+            if (_strictAllocationMode && JobPool.JobCount >= _maxConcurrentJobs)
+            {
+                throw new MaximumConcurrentJobCountExceededException();
+            }
             jobId = JobPool.Schedule();
         }
 
@@ -192,6 +266,8 @@ public class JobScheduler : IDisposable
     /// <param name="job">The job to process</param>
     /// <param name="dependency">A job that must complete before this job can be run</param>
     /// <returns>Its <see cref="JobHandle"/>.</returns>
+    /// <exception cref="InvalidOperationException">If called on a different thread than the <see cref="JobScheduler"/> was constructed on</exception>
+    /// <exception cref="MaximumConcurrentJobCountExceededException">If the maximum amount of concurrent jobs is at maximum, and strict mode is enabled.</exception>
     public JobHandle Schedule(IJob job, JobHandle? dependency = null)
     {
         if (dependency is not null) CheckForSchedulerEquality(dependency.Value);
@@ -206,6 +282,8 @@ public class JobScheduler : IDisposable
     /// called on this task (or one of its dependants). If the data is modified, the dependency system will break.</remarks>
     /// <param name="dependencies">A list of handles to depend on.</param>
     /// <returns>The combined <see cref="JobHandle"/></returns>
+    /// <exception cref="InvalidOperationException">If called on a different thread than the <see cref="JobScheduler"/> was constructed on</exception>
+    /// <exception cref="MaximumConcurrentJobCountExceededException">If the maximum amount of concurrent jobs is at maximum, and strict mode is enabled.</exception>
     // TODO: consider doing some native allocation or cache to track these? would remove need to transfer ownership to user
     public JobHandle CombineDependencies(JobHandle[] dependencies)
     {


### PR DESCRIPTION
Fixes #11 and #10

Also fixes a small allocation issue I noticed: `CompleteAll(IList<JobHandle> handles)` allocates due to iteration over `IList` since it's just casting to `IEnumerable` to do so. (`IEnumerable` always allocates every iteration when enumerating because `GetEnumerator` returns `IEnumerator` which is usually a struct and must be boxed. Dunno why the JIT can't figure that one out but oh well.) Changed it to `List<JobHandle>`.

Adds the ability to configure `JobScheduler` to start with a maximum number of concurrent job slots to frontload allocation/garbage creation, and an optional strict mode that will throw if those slots are exceeded.

Adds some additional benchmarks and testing, and revises what was already there to be more accurate.

Adds documentation accordingly.

