### PR TITLE
Better dependency algorithm

### DIFF
--- a/JobScheduler/JobPool.cs
+++ b/JobScheduler/JobPool.cs
@@ -9,24 +9,44 @@ namespace JobScheduler;
 /// </summary>
 internal record struct Job
 {
-    
+
     /// <summary>
     ///     Creates a new <see cref="Job"/> instance.
     /// </summary>
     /// <param name="jobId">The <see cref="JobId"/>.</param>
     /// <param name="waitHandle">Its <see cref="ManualResetEvent"/>.</param>
-    public Job(JobId jobId, ManualResetEvent? waitHandle)
+    /// <param name="dependents">The initial list of dependents this Job has</param>
+    /// <param name="jobWork">The job work associated with this Job</param>
+    public Job(JobId jobId, ManualResetEvent? waitHandle, List<JobId> dependents, IJob? jobWork)
     {
         JobId = jobId;
         WaitHandle = waitHandle;
+        Dependents = dependents;
+        JobWork = jobWork;
     }
 
     internal JobId JobId { get; }
 
     /// <summary>
+    /// The actual code of the job.
+    /// </summary>
+    public IJob? JobWork { get; }
+
+    /// <summary>
     /// The Handle of the job. 
     /// </summary>
     public ManualResetEvent? WaitHandle { get; }
+
+    /// <summary>
+    /// The list of dependents this job has (NOT dependencies!)
+    /// When this job completes it will decrease the <see cref="DependencyCount"/> of any dependants.
+    /// </summary>
+    public List<JobId> Dependents { get; }
+
+    /// <summary>
+    /// The number of Dependencies (NOT dependants!) that must complete before this job can be added to the queue
+    /// </summary>
+    public int DependencyCount { get; set; } = 0;
 
     /// <summary>
     /// When this hits 0, we can dispose the WaitHandle, and the JobID
@@ -72,14 +92,18 @@ internal class JobPool
         _recycledIds = new(capacity);
         ManualResetEventPool = new(new ManualResetEventPolicy(), capacity);
 
-        for (int i = 0; i < capacity; i++) ManualResetEventPool.Return(new(false));
+        for (int i = 0; i < capacity; i++)
+        {
+            ManualResetEventPool.Return(new(false));
+            _jobs[i] = new Job(new(-1, -1), null, new(capacity - 1), null);
+        }
     }
 
     /// <summary>
     /// Create a new <see cref="Job"/> in the pool, with an optional dependency
     /// </summary>
     /// <returns>The <see cref="JobId"/> of the created job</returns>
-    public JobId Schedule()
+    public JobId Schedule(List<JobId> dependencies, IJob? work, out bool ready)
     {
         if (!_recycledIds.TryDequeue(out JobId id))
         {
@@ -87,16 +111,40 @@ internal class JobPool
             _nextId++;
         }
 
-        var job = new Job(id, ManualResetEventPool.Get());
-        Debug.Assert(job.WaitHandle is not null);
-        job.WaitHandle.Reset(); // must reset when acquiring
-
         // Adjust array size
         if (_jobs.Length <= id.Id)
         {
-            Array.Resize(ref _jobs, _jobs.Length * 2);    
+            int oldSize = _jobs.Length;
+            Array.Resize(ref _jobs, _jobs.Length * 2);
+            // make lists
+            for (int i = oldSize; i < _jobs.Length; i++)
+            {
+                // don't worry about allocating a size of the list; if we're resizing we're spontaneously allocating anyways so we don't want to overuse memory
+                _jobs[i] = new Job(new(-1, -1), null, new(), null);
+            }
         }
-        
+
+        int dependencyCount = 0;
+        if (dependencies is not null)
+        {
+            foreach (var dependency in dependencies)
+            {
+                ValidateJobId(dependency);
+                if (IsComplete(dependency)) continue;
+                dependencyCount++;
+                var d = _jobs[dependency.Id];
+                d.Dependents.Add(id);
+            }
+        }
+
+        ready = dependencyCount == 0; // we don't have any active dependencies
+
+        var job = new Job(id, ManualResetEventPool.Get(), _jobs[id.Id].Dependents, work);
+        Debug.Assert(job.Dependents.Count == 0);
+        Debug.Assert(job.WaitHandle is not null);
+        job.WaitHandle.Reset(); // must reset when acquiring
+        job.DependencyCount = dependencyCount;
+
         _jobs[id.Id] = job;
         JobCount++;
         return id;
@@ -112,8 +160,9 @@ internal class JobPool
         var job = _jobs[jobId.Id];
         Debug.Assert(job.IsComplete);
         Debug.Assert(job.WaitHandle is not null);
+        Debug.Assert(job.Dependents.Count == 0); // we should've already processed dependents
 
-        _jobs[jobId.Id] = new(new(-1, -1), null);
+        _jobs[jobId.Id] = new(new(-1, -1), null, job.Dependents, null);
         JobCount--;
         jobId.Version++;
         
@@ -165,17 +214,32 @@ internal class JobPool
             Return(jobId);
         }
     }
-    
+
     /// <summary>
-    ///     Mark a <see cref="Job"/> as Complete by its <see cref="JobId"/>.
-    ///     Removing it from circulation entirely. The <see cref="ManualResetEvent"/> is not disposed yet.
+    ///     Mark a <see cref="Job"/> as Complete by its <see cref="JobId"/>, removing it from circulation entirely.
+    ///     The <see cref="ManualResetEvent"/> is not disposed yet, unless there are no subscribers.
     /// </summary>
     /// <param name="jobId">The <see cref="JobId"/>.</param>
-    public ManualResetEvent? MarkComplete(JobId jobId)
+    /// <param name="readyDependencies">Filled with any dependencies that are now ready for execution.</param>
+    /// <returns>The <see cref="ManualResetEvent"/>, if there were subscribers that the caller must notify.</returns>
+    public ManualResetEvent? MarkComplete(JobId jobId, List<(JobId ID, IJob? Work)> readyDependencies)
     {
         ValidateJobNotComplete(jobId);
         var job = _jobs[jobId.Id];
         job.IsComplete = true;
+        foreach (var dependent in job.Dependents)
+        {
+            var d = _jobs[dependent.Id];
+            Debug.Assert(d.DependencyCount > 0);
+            d.DependencyCount--;
+            if (d.DependencyCount == 0)
+            {
+                readyDependencies.Add((dependent, d.JobWork));
+            }
+            _jobs[dependent.Id] = d;
+        }
+
+        job.Dependents.Clear();
         _jobs[jobId.Id] = job;
 
         if (job.WaitHandleSubscriptionCount > 0)
@@ -187,6 +251,16 @@ internal class JobPool
         // we do not have subscribers, so the handle was never used
         Return(jobId);
         return null;
+    }
+
+    /// <summary>
+    /// Returns whether this job is ready to run, i.e. has 0 incomplete dependencies.
+    /// </summary>
+    public bool IsReady(JobId jobId)
+    {
+        ValidateJobNotComplete(jobId);
+        var job = _jobs[jobId.Id];
+        return job.DependencyCount == 0;
     }
     
 


### PR DESCRIPTION
Fixes #12. Implements the algorithm I wrote out in #16.

Note: Increases memory pressure to `O(n^2)` where `n = MaxExpectedConcurrentJobs`.

Comes with some absolutely bizarre performance increases:

Before:

| Method                | Threads | ConcurrentJobs | MaxConcurrentJobs | Waves | Mean       | Error    | StdDev   | Allocated |
|---------------------- |-------- |--------------- |------------------ |------ |-----------:|---------:|---------:|----------:|
| **BenchmarkSequential**   | **0**       | **32**             | **32**                | **1024**  |   **353.2 ms** |  **4.14 ms** |  **3.67 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 32                | 1024  |   124.6 ms |  1.91 ms |  1.79 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **32**             | **2048**              | **1024**  |   **358.1 ms** |  **2.85 ms** |  **2.67 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 2048              | 1024  |   128.7 ms |  1.17 ms |  1.04 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **128**            | **32**                | **1024**  | **1,430.5 ms** | **21.28 ms** | **19.90 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 32                | 1024  |   724.9 ms |  2.56 ms |  2.39 ms | 5532392 B |
| **BenchmarkSequential**   | **0**       | **128**            | **2048**              | **1024**  | **1,433.1 ms** | **13.07 ms** | **12.23 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 2048              | 1024  |   709.9 ms |  2.37 ms |  2.21 ms |     600 B |

After: 

| Method                | Threads | ConcurrentJobs | MaxConcurrentJobs | Waves | Mean        | Error     | StdDev    | Allocated |
|---------------------- |-------- |--------------- |------------------ |------ |------------:|----------:|----------:|----------:|
| **BenchmarkSequential**   | **0**       | **32**             | **32**                | **1024**  |   **353.34 ms** |  **2.671 ms** |  **2.498 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 32                | 1024  |    39.77 ms |  0.347 ms |  0.307 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **32**             | **2048**              | **1024**  |   **357.67 ms** |  **2.897 ms** |  **2.710 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 2048              | 1024  |    42.00 ms |  0.381 ms |  0.357 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **128**            | **32**                | **1024**  | **1,427.78 ms** | **10.038 ms** |  **8.898 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 32                | 1024  |   187.53 ms |  0.461 ms |  0.431 ms | 5524920 B |
| **BenchmarkSequential**   | **0**       | **128**            | **2048**              | **1024**  | **1,437.30 ms** | **14.805 ms** | **13.124 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 2048              | 1024  |   172.52 ms |  0.513 ms |  0.454 ms |     600 B |


So yeah, 3-4x overhead improvement when it comes to a long dependency chain. Genuinely not sure where this comes from; I had to re-check twice. If you've got any insight let me know. Either way, hey, I'll take it.