### PR TITLE
Work Stealing

### DIFF
--- a/JobScheduler.Test/CombineDependenciesTests.cs
+++ b/JobScheduler.Test/CombineDependenciesTests.cs
@@ -82,7 +82,7 @@ internal class CombineDependenciesTests : SchedulerTestFixture
         // this should be kept as low as possible to avoid long test times.
         // the goal is to get it as small as possible without the threads outrunning the main thread (because if that happens, everything will
         // complete without us testing whether it's completing in the right order!)
-        int timeout = 1;
+        int timeout = 5;
 
         List<DependencyChainElement> chain = new();
         for (int i = 0; i < chainLength; i++)

--- a/JobScheduler.Test/JobSchedulerTests.cs
+++ b/JobScheduler.Test/JobSchedulerTests.cs
@@ -13,10 +13,10 @@ internal class JobSchedulerTests : SchedulerTestFixture
         var numThreads = ThreadCount;
         if (numThreads <= 0) numThreads = Environment.ProcessorCount;
         Thread.Sleep(10); // wait for threads to spawn
-        Assert.That(Scheduler.ThreadsActive, Is.EqualTo(numThreads));
+        Assert.That(Scheduler.ThreadsAlive, Is.EqualTo(numThreads));
         Scheduler.Dispose();
         Thread.Sleep(10);
-        Assert.That(Scheduler.ThreadsActive, Is.EqualTo(0));
+        Assert.That(Scheduler.ThreadsAlive, Is.EqualTo(0));
     }
 
     private class ExceptionJob : IJob

--- a/JobScheduler/Deque/CircularArray.cs
+++ b/JobScheduler/Deque/CircularArray.cs
@@ -1,0 +1,67 @@
+﻿namespace JobScheduler.Deque;
+
+/// <summary>
+/// A <see cref="CircularArray{T}"/> as found in Chase and Lev pg. 3 [1]
+/// </summary>
+/// <remarks>
+///     [1] Chase, D., &amp; Lev, Y. (2005). Dynamic circular work-stealing deque. Proceedings of the Seventeenth Annual ACM
+///         Symposium on Parallelism in Algorithms and Architectures. https://doi.org/10.1145/1073970.1073974.
+///         Retrieved October 17, 2023, from https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf.
+/// </remarks>
+/// <typeparam name="T"></typeparam>
+internal class CircularArray<T>
+{
+    private readonly int _logSize;
+    private readonly T[] _segment;
+
+    /// <summary>
+    /// Create a new <see cref="CircularArray{T}"/> with log_2(capacity) of at least <paramref name="logSize"/>.
+    /// </summary>
+    /// <param name="logSize"></param>
+    // equivalent to CircularArray(int log_size) in Chase and Lev
+    public CircularArray(int logSize)
+    {
+        _logSize = logSize;
+        _segment = new T[Capacity];
+    }
+
+    /// <summary>
+    /// Returns the current capacity of the array.
+    /// </summary>
+    // equivalent to size() in Chase and Lev
+    public long Capacity => 1 << _logSize;
+
+    /// <summary>
+    /// Get or set at an index of the array. If the index is greater than the array length, wraps around the array.
+    /// </summary>
+    /// <param name="i"></param>
+    /// <returns></returns>
+    public T this[long i]
+    {
+        // equivalent to get(long i) in Chase and Lev
+        get => _segment[i % Capacity];
+        // equivalent to put(long i, Object o) in Chase and Lev
+        set => _segment[i % Capacity] = value;
+    }
+
+    /// <summary>
+    ///     Grow the array by 2, copying the old array from a given <paramref name="b"/> and <paramref name="t"/>.
+    /// </summary>
+    /// <remarks>
+    ///     The copied elements are guaranteed to map to the same indices from <paramref name="b"/> to
+    ///     <paramref name="t"/>, no matter how large those indices are. Any other indices will not map properly, however.
+    /// </remarks>
+    /// <param name="t"></param>
+    /// <param name="b"></param>
+    /// <returns></returns>
+    // equivalent to grow(long b, long t) in Chase and Lev
+    public CircularArray<T> Grow(long b, long t)
+    {
+        CircularArray<T> newArray = new(_logSize + 1);
+        for (long i = t; i < b; i++)
+        {
+            newArray[i] = this[i];
+        }
+        return newArray;
+    }
+}

--- a/JobScheduler/Deque/CircularArray.cs
+++ b/JobScheduler/Deque/CircularArray.cs
@@ -55,7 +55,7 @@ internal class CircularArray<T>
     /// <param name="b"></param>
     /// <returns></returns>
     // equivalent to grow(long b, long t) in Chase and Lev
-    public CircularArray<T> Grow(long b, long t)
+    public CircularArray<T> EnsureCapacity(long b, long t)
     {
         CircularArray<T> newArray = new(_logSize + 1);
         for (long i = t; i < b; i++)

--- a/JobScheduler/Deque/WorkStealingDeque.cs
+++ b/JobScheduler/Deque/WorkStealingDeque.cs
@@ -135,7 +135,7 @@ internal class WorkStealingDeque<T>
             long actualSize = b - t;
             if (actualSize >= a.Capacity - 1)
             {
-                a = a.Grow(b, t);
+                a = a.EnsureCapacity(b, t);
                 _activeArray = a;
             }
         }
@@ -232,7 +232,10 @@ internal class WorkStealingDeque<T>
         long size = b - t;
 
         // If we're empty, don't even try.
-        if (size <= 0) return false;
+        if (size <= 0)
+        {
+            return false;
+        }
         // We know we're not empty, so give it a shot:
         T stolen = a[t];
 

--- a/JobScheduler/Deque/WorkStealingDeque.cs
+++ b/JobScheduler/Deque/WorkStealingDeque.cs
@@ -1,0 +1,251 @@
+﻿namespace JobScheduler.Deque;
+
+/// <summary>
+///     A <see cref="WorkStealingDeque{T}"/> is an implementation of the Chase &amp; Lev Dynamic Circular Work-Stealing Deque [1]
+///     It is thread safe, lock-free, and concurrent, but with a caveat: It must have an owner process that exclusively calls
+///     <see cref="TryPopBottom(out T)"/> and <see cref="PushBottom(T)"/>. Any number of child stealers can call
+///     <see cref="TrySteal(out T)"/> concurrently.
+/// </summary>
+/// <remarks>
+///     While Chase &amp; Lev provide several options for memory management, we choose to let resizes discard of the additional
+///     memory through GC. This is because we don't expect to frequently grow, or to shrink at all, given our API.
+///     [1] Chase, D., &amp; Lev, Y. (2005). Dynamic circular work-stealing deque. Proceedings of the Seventeenth Annual ACM
+///         Symposium on Parallelism in Algorithms and Architectures. ⟨10.1145/1073970.1073974⟩.
+///         Retrieved October 17, 2023, from https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf.
+///     [2] Nhat Minh Lê, Antoniu Pop, Albert Cohen, Francesco Zappa Nardelli. Correct and Efficient Work-Stealing for Weak Memory
+///         Models. PPoPP '13 - Proceedings of the 18th ACM SIGPLAN symposium on Principles and practice of parallel programming,
+///         Feb 2013, Shenzhen, China. pp.69-80, ⟨10.1145/2442516.2442524⟩. ⟨hal-00802885⟩. Retrieved October 17, 2023 from
+///         https://hal.science/hal-00786679/.
+/// </remarks>
+/// <typeparam name="T"></typeparam>
+internal class WorkStealingDeque<T>
+{
+    // This class operates on two fundamental insights:
+    //
+    //    1. _top never decrements
+    //    2. _bottom is only ever modified by the owning process.
+    //
+    // This means that modifying _bottom is "free," i.e. while pushing/popping to the bottom (our process's "owned half") we
+    // don't have to worry about concurrence issues.
+    //
+    // This also means that when concurrence issues do come up, either with stealing, or with popping from an almost-empty queue,
+    // we can always rely on CAS-incrementing _top to tell us whether a race-condition occured.
+    //
+    // I.e. if our _top is equal to the actual top, we can CAS, and therefore we won the race. Otherwise, someone else (or even multiple
+    // others) incremented _top first, and we lost the race, so we give up our operation.
+    // 
+    // Other than that, it's a very standard CircularArray-based Deque, where the top and bottom pointers move around depending on the
+    // operation. The owner pushes and pops from the bottom, moving the bottom around wherever, and the stealer pops from the top, exclusively
+    // raising the top value and never EVER lowering it.
+    //
+    // This isn't a complete Deque, because the operation PushTop would force us to decrement Top (which would violate our ability to use CAS
+    // to act as a "version" of the top). 
+    // 
+    // A valid array can be visualized like this:
+    //     t        b
+    // [_  x  y  z  _  _]
+    // t = _top pointer
+    // b = _bottom pointer
+    // x, y, z = valid elements in the Deque
+    //
+    // This array is used as the starting point for all the following operation examples.
+    //
+    // Pushing a to the bottom looks like this (incrementing bottom to make the queue bigger; ONLY thread-safe from the owning thread):
+    //     t           b
+    // [_  x  y  z  a  _]
+    // 
+    // Stealing* looks like this (incrementing top to make the queue smaller; thread-safe):
+    //        t     b
+    // [_  _  y  z  _  _]  => stole x!
+    // 
+    // Popping* z from the bottom looks like this (decrementing bottom to make the queue smaller; ONLY thread-safe from the owning thread):
+    //     t     b
+    // [_  x  y  _  _  _] => popped z!
+    //
+    // *These methods might conflict with each other, which is why we check _top in both methods after we do most of the operation to
+    // ensure it's still valid.
+
+    // This must be specifically atomically accessed/modified because c# doesn't support volatile longs.
+    // Use Volatile.Read/Volatile.Write, which is OK because _bottom is only written from one processor.
+    private long _bottom = 0;
+
+    // The same should apply to _top, but it doesn't. I don't know why.
+    // The original algorithm uses volatile to read _top and CAS to write _top.
+    // However, when we do the same, multiple steal operations accidentally grab the same variable, sometimes.
+    // (VERY VERY VERY occasionally. Only really observable through high-stress benchmarks in my experience.)
+    // (If you want to test, run on a Debug configuration with new DebugInProcessConfig(), because the already-complete
+    // job validation is only run on Debug.)
+    // From research, the only difference between Interlocked.Read and Volatile.Read is that Volatile might access
+    // a slightly old version of the variable, which our code should be able to deal with since CASTop checks that.
+    // But it doesn't work.
+    // If anyone has ideas, speak up. This could be caused by...
+    //     * A weird edge-case in .NET
+    //     * An oversight in the original algorithm (but what?)
+    //     * A misunderstanding on my part of how this works
+    // Instead, for now, use Interlocked.Read to access _top no matter what.
+    // (It's not an issue with the volatile modifier vs. the Volatile class; volatile modifier on ints fails as well)
+    // Nhat et al. [2] might have some insight into this, hidden inside the C++ code, but it's far more low-level than
+    // we get here, and therefore of limited use.
+    private long _top = 0;
+
+    // According to section 2.3, we keep a cache of the last top value, to guess at the size of the Deque
+    // so we don't have to look at _top every time.
+    // We init to 0 because the cached size will be b - 0, and we know that, since t < b, that will give a
+    // larger-than-life value.
+    private long _lastTopValue = 0;
+
+    private volatile CircularArray<T> _activeArray;
+
+    /// <summary>
+    /// Create a new <see cref="WorkStealingDeque{T}"/> with capacity of at least <paramref name="capacity"/>.
+    /// </summary>
+    /// <param name="capacity"></param>
+    public WorkStealingDeque(int capacity)
+    {
+        _activeArray = new CircularArray<T>((int)Math.Ceiling(Math.Log(capacity, 2)));
+    }
+
+    // Is oldVal equal to our current top? If so, we're good; exchange them and return true. If not, we went
+    // out of date at some point. Don't exchange them, and return false.
+    private bool CASTop(long oldVal, long newVal)
+    {
+        return Interlocked.CompareExchange(ref _top, newVal, oldVal) == oldVal;
+    }
+
+    /// <summary>
+    ///     Push an item to the bottom of the <see cref="WorkStealingDeque{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This method must ONLY be called by the deque's owning process, ever!
+    ///     It is not concurrent with itself, only with <see cref="TrySteal(out T)"/>
+    /// </remarks>
+    /// <param name="item">The item to add.</param>
+    public void PushBottom(T item)
+    {
+        long b = Volatile.Read(ref _bottom);
+        CircularArray<T> a = _activeArray;
+
+        // we use the cached value per section 2.3, to avoid a blocking top read
+        long sizeUpperBound = b - _lastTopValue;
+        if (sizeUpperBound >= a.Capacity - 1)
+        {
+            // we think we might need a resize, but we're not sure, so access the volatile variable.
+            var t = Interlocked.Read(ref _top);
+            _lastTopValue = t; // cache it
+            long actualSize = b - t;
+            if (actualSize >= a.Capacity - 1)
+            {
+                a = a.Grow(b, t);
+                _activeArray = a;
+            }
+        }
+        a[b] = item;
+
+        // Incrementing the bottom is always safe, because Steal never changes bottom.
+        // Steal can only ever change top.
+        Volatile.Write(ref _bottom, b + 1);
+    }
+
+
+    /// <summary>
+    ///     Attempt to pop an item from the bottom of the <see cref="WorkStealingDeque{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This method must ONLY be called by the deque's owning process, ever!
+    ///     It is not concurrent with itself, only with <see cref="TrySteal(out T)"/>
+    /// </remarks>
+    /// <param name="item">Set to the popped item if success. If no success, undefined.</param>
+    /// <returns>True if we popped successfully and therefore <paramref name="item"/> contains useful data.</returns>
+    public bool TryPopBottom(out T item)
+    {
+        // we make no guarantees about what this even does if we return false
+        item = default!;
+
+        long b = Volatile.Read(ref _bottom);
+        CircularArray<T> a = _activeArray;
+
+        // we're popping, so decrement the bottom in advance.
+        // Doing this in advance ensures that we "reserve space" in the size, so that even if someone steals,
+        // they can't steal past this _bottom (their size would return 0, and they wouldn't steal). 
+        // At the end of this method, if we need to adjust this (i.e. there ended up being nothing to steal)
+        // we resolve this.
+        b--;
+        Volatile.Write(ref _bottom, b);
+
+        // check the size...
+        long t = Interlocked.Read(ref _top);
+        long size = b - t;
+
+        // if we were empty before, we're still empty, so we just make sure we're canon (top == bottom).
+        if (size < 0)
+        {
+            Volatile.Write(ref _bottom, t);
+            return false;
+        }
+
+        // if we're not empty even after the pop, we're good to go.
+        // This means we can pop even without the expensive CAS!
+        T popped = a[b];
+        if (size > 0)
+        {
+            item = popped;
+            return true;
+        }
+
+        // But what if the pop makes it empty? We need to check to see if we won a race with any Stealers.
+        // If this returns false, we lost the race, because our t value became out of date. (Steal did this operation instead).
+        // Note that incrementing _top if we're empty is totally OK because top > bottom is always empty.
+        if (!CASTop(t, t + 1))
+        {
+            // We lost the race, and the queue is now empty.
+            // Reset to empty canon:
+            Volatile.Write(ref _bottom, t + 1);
+            return false;
+        }
+
+        // We won the race! Return the item and reset to canon.
+        Volatile.Write(ref _bottom, t + 1);
+        item = popped;
+        return true;
+    }
+
+    /// <summary>
+    ///     Attempt to steal an item from the top of the <see cref="WorkStealingDeque{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike <see cref="PushBottom"/> and <see cref="TryPopBottom"/>, this method can be called from any thread
+    ///     at any time, and it is guaranteed to be concurrently compatible with all other methods including itself.
+    /// </remarks>
+    /// <param name="item">Set to the stolen item if success. If no success, undefined.</param>
+    /// <returns>True if we stole successfully and therefore <paramref name="item"/> contains useful data.</returns>
+    public bool TrySteal(out T item)
+    {
+        // We make no guarantees about what this even does if we return false
+        item = default!;
+        long t = Interlocked.Read(ref _top);
+        long b = Volatile.Read(ref _bottom);
+        // In case the array gets resized, we grab a reference to the old one.
+        // That will protect it from the GC while we do this method.
+        // Since the array (in this implementation) only gets resized on push, the top index must be where we expect.
+        // Unless the top index changes: in which case we got out-raced and we'll exit later.
+        CircularArray<T> a = _activeArray;
+        long size = b - t;
+
+        // If we're empty, don't even try.
+        if (size <= 0) return false;
+        // We know we're not empty, so give it a shot:
+        T stolen = a[t];
+
+        // Check for a race between TryPopBottom, other stealers, and us.
+        // If we successfully increment the top (decreasing the size of the deque), we win.
+        if (!CASTop(t, t + 1))
+        {
+            // We lose and return false since someone else got to the item before we did.
+            return false;
+        }
+
+        // We won!
+        item = stolen;
+        return true;
+    }
+}

--- a/JobScheduler/JobScheduler.WorkStealing.cs
+++ b/JobScheduler/JobScheduler.WorkStealing.cs
@@ -1,0 +1,359 @@
+﻿namespace JobScheduler;
+
+// This section of JobScheduler deals with the implementation of the algorithm found here: https://tsung-wei-huang.github.io/papers/icpads20.pdf [1]
+// [1] Lin, C.-X., Huang, T.-W., & Wong, M. D. (2020). An efficient work-stealing scheduler for task dependency graph. 2020 IEEE 26th
+//      International Conference on Parallel and Distributed Systems (ICPADS). https://doi.org/10.1109/icpads51040.2020.00018 
+public partial class JobScheduler
+{
+    // The Lin et al. version uses an Eventcount, which I don't fully understand and definitely can't implement.
+    // Here's the best compilation of documentation I've found on them: https://gist.github.com/mratsim/04a29bdd98d6295acda4d0677c4d0041
+    // I haven't seen any .NET implementations.
+    // For now, this is fine: the requirement the paper presents is that the notifier must be able to wake a single thread, or multiple threads, and wait.
+    private class Notifier
+    {
+        // lets 1 thread through when Set(), then immediately resets
+        readonly AutoResetEvent _singleNotifier = new(false);
+
+        // lets all threads through when Set() until manually reset
+        // we only use this to notify all for an exit condition
+        readonly ManualResetEvent _multipleNotifier = new(false);
+        readonly WaitHandle[] _both;
+
+        public bool IsDisposed { get; private set; } = false;
+
+        public Notifier()
+        {
+            _both = new WaitHandle[2];
+            _both[0] = _singleNotifier;
+            _both[1] = _multipleNotifier;
+        }
+
+        // block thread until a notification comes from any source
+        public void Wait()
+        {
+            WaitHandle.WaitAny(_both);
+        }
+
+        // notify a single other thread
+        public void NotifyOne()
+        {
+            _singleNotifier.Set();
+        }
+
+        // notify all other threads. currently permanent; can't close this gate again.
+        // it's ok because we only use this to notify for an exit.
+        public void NotifyAll()
+        {
+            // occasionally we might have an issue where we notify from the main thread when already disposed
+            // this prevents that
+            // this isn't a perf-effecting lock because it only happens when we're done
+            lock (_disposeLock)
+            {
+                if (IsDisposed) return;
+                _multipleNotifier.Set();
+            }
+        }
+
+        private readonly object _disposeLock = new();
+
+        public void Dispose()
+        {
+            lock (_disposeLock)
+            {
+                if (IsDisposed) return;
+                IsDisposed = true;
+                _singleNotifier.Dispose();
+                _multipleNotifier.Dispose();
+            }
+        }
+    }
+
+    private class WorkerData
+    {
+        public WorkerData(int id, int maxJobs)
+        {
+            Id = id;
+            ReadyDependencyCache = new(maxJobs - 1);
+        }
+        public int Id { get; }
+        public JobMeta? Cache { get; set; } = null;
+
+        // TEMPORARY: we're using LinkedList + locks here as a Deque, but it needs to be a proper concurrent Deque.
+        // Must be temporary because LinkedList is not zero alloc.
+        //
+        // One package that achieves this is DequeNET https://github.com/dcastro/DequeNET. We can either include the Nuget package
+        // or grab the code (it's MIT licensed). It's based on the Michael queue. [2]
+        // [2] Michael, Maged, 2003, CAS-Based Lock-Free Algorithm for Shared Deques, Euro-Par 2003 Parallel Processing, v. 2790, p. 651-660,
+        // http://www.research.ibm.com/people/m/michael/europar-2003.pdf (Decembre 22, 2013).
+        // ^ Link is dead PDF is findable.
+        //
+        // However, Lin et al. use the Chase-Lev deque: https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf [3]
+        // [3] David Chase and Yossi Lev. Dynamic circular work-stealing deque. In SPAA, pages 21–28. ACM, 2005.
+        // A Chase-Lev deque is here, in C++ https://github.com/ConorWilliams/ConcurrentDeque (Mozilla Public License 2.0; weak copyleft)
+        // Here's one in Rust http://huonw.github.io/parry/deque/index.html (Apache 2.0)
+        // Nobody's made a C# implementation yet. But we could; it looks doable. The original paper is in Java which makes it easier.
+        public LinkedList<JobMeta> Deque { get; } = new();
+        public object DequeLock { get; } = new();
+
+        // store this to cache the output from JobPool per thread
+        public List<(JobId, IJob?)> ReadyDependencyCache { get; }
+    }
+
+    private int _stealBound = 0;
+    private readonly int _yieldBound = 100;
+
+    private int _numActives = 0;
+    private int _numThieves = 0;
+
+    private readonly Notifier _notifier = new();
+    private readonly Random _random = new();
+
+    private WorkerData[] _workers = null!;
+    private CancellationToken _token;
+
+    private void InitAlgorithm(int threadCount, int maxJobs, CancellationToken token)
+    {
+        _stealBound = 2 * (threadCount - 1);
+        _workers = new WorkerData[threadCount];
+
+        for (int i = 0; i < _workers.Length; i++)
+        {
+            _workers[i] = new WorkerData(i, maxJobs);
+        }
+        _token = token;
+    }
+
+
+    // algorithm 2
+    private void WorkerLoop(object data)
+    {
+        var worker = (int)data;
+        JobMeta? task = null;
+        var workerData = _workers[worker];
+        while (true)
+        {
+            // execute the task
+            ExploitTask(ref task, workerData);
+            // steal and/or wait for the next task
+            if (!WaitForTask(ref task, workerData))
+            {
+                break;
+            }
+        }
+
+        if (Interlocked.Decrement(ref _threadsAlive) == 0)
+        {
+            // if we're the last thread active, we don't need this event
+            // to unblock potentially active threads anymore.
+            _notifier.Dispose();
+        }
+    }
+
+    // actually do the execution of a task
+    private void Execute(in JobMeta task, WorkerData workerData)
+    {
+        // it might be null if this is a job generated with CombineDependencies
+        task.Job?.Execute();
+
+        // the purpose of this lock is to ensure that the Complete method always subscribes and listens to an existant signal.
+        ManualResetEvent? handle;
+        var readyDependencies = workerData.ReadyDependencyCache;
+        readyDependencies.Clear();
+        lock (JobPool)
+        {
+            // remove the job from circulation
+            handle = JobPool.MarkComplete(task.JobID, readyDependencies);
+        }
+
+        if (readyDependencies.Count > 0)
+        {
+            // queue up in our personal queue for work-stealing
+            // cache the first one
+            workerData.Cache = new(readyDependencies[0].Item1, readyDependencies[0].Item2);
+            lock (workerData.DequeLock)
+            {
+                // queue up any additionals
+                for (int i = 1; i < readyDependencies.Count; i++)
+                {
+                    var tup = readyDependencies[i];
+                    workerData.Deque.AddFirst(new JobMeta(tup.Item1, tup.Item2));
+                }
+            }
+        }
+        else
+        {
+            workerData.Cache = null;
+        }
+
+        // If JobScheduler.Complete was called on this job by a different thread, it told the job pool with Subscribe that we should ping,
+        // and that Complete would handle recycling. We notify the event here.
+        handle?.Set();
+    }
+
+    // pops from our own queue
+    private void Pop(out JobMeta? task, WorkerData workerData)
+    {
+        task = null;
+        lock (workerData.DequeLock)
+        {
+            if (workerData.Deque.First is not null)
+            {
+                task = workerData.Deque.First.Value;
+                workerData.Deque.RemoveFirst();
+            }
+        }
+    }
+
+    // steals from a victim's queue
+    private void StealFrom(out JobMeta? task, WorkerData workerData)
+    {
+        task = null;
+        lock (workerData.DequeLock)
+        {
+            if (workerData.Deque.Last is not null)
+            {
+                task = workerData.Deque.Last.Value;
+                workerData.Deque.RemoveLast();
+            }
+        }
+    }
+
+    // algorithm 3
+    private void ExploitTask(ref JobMeta? task, WorkerData workerData)
+    {
+        // if we incremented _numActives from 0 to 1, and there aren't any thieves currently active.
+        // it means we need to notify additional threads to pick up more work, because they aren't pulling their weight.
+        if (Interlocked.Increment(ref _numActives) == 1 && _numThieves == 0)
+        {
+            _notifier.NotifyOne();
+        }
+
+        do
+        {
+            if (task is not null) Execute(task.Value, workerData);
+            if (workerData.Cache is not null)
+            {
+                // we cache our next task to work on, if available
+                task = workerData.Cache;
+            }
+            else
+            {
+                // otherwise, we just pop from our queue
+                Pop(out task, workerData);
+            }
+        }
+        while (task is not null);
+
+        Interlocked.Decrement(ref _numActives);
+    }
+
+    // algorithm 5
+    private bool WaitForTask(ref JobMeta? task, WorkerData workerData)
+    {
+        WaitForTask:
+        // it's stealing time!
+        Interlocked.Increment(ref _numThieves);
+        // do the actual steal
+        ExploreTask(ref task, workerData);
+
+        // if we succeeded in stealing, return true.
+        if (task is not null)
+        {
+            // if we were the last thief active, we'd better wake another one up.
+            if (Interlocked.Decrement(ref _numThieves) == 0)
+            {
+                _notifier.NotifyOne();
+            }
+            return true;
+        }
+
+        // we failed stealing even after multiple tries, so we have to wait.
+
+        // First, though, we check the master queue in case anything's been added
+        // (is this necessary without Eventcount? I'm not sure.)
+        if (MasterQueue.TryDequeue(out var stolenTask))
+        {
+            // oh wait, we actually can take from the master queue.
+            task = stolenTask;
+
+            // we succeeded in taking!
+            // if we were the last thief active, we'd better wake another one up.
+            if (Interlocked.Decrement(ref _numThieves) == 0)
+            {
+                _notifier.NotifyOne();
+            }
+            return true;
+        }
+
+        // NOTE: The original algorithm has a check on the queue count prior to TryDequeue. Then, if the TryDequeue fails,
+        // it tries the whole entire stealing algorithm again!
+        // I.e., when a worker looks at the master queue count, and tries to steal but fails, it means some other worker stole
+        // instead and the queue is now empty.
+        // I'm not sure why they do that, and they don't explain.
+        // But I think it's not relevant anymore since we're not using Eventcount and we're using a ConcurrentQueue.
+
+        // If we're finished, don't start waiting
+        if (_token.IsCancellationRequested)
+        {
+            // tell everyone else we're finished
+            _notifier.NotifyAll();
+            Interlocked.Decrement(ref _numThieves);
+            return false;
+        }
+
+        // If we were the last thief, but there are actives, we try again (pretend like we're a newly notified thief).
+        if (Interlocked.Decrement(ref _numThieves) == 0 && _numActives > 0)
+        {
+            goto WaitForTask;
+        }
+
+        // We wait here, now that we're positive no work remains.
+        _notifier.Wait();
+        return true;
+    }
+
+    // algorithm 4
+    private void ExploreTask(ref JobMeta? task, WorkerData workerData)
+    {
+        int numFailedSteals = 0;
+        int numYields = 0;
+
+        while (!_token.IsCancellationRequested)
+        {
+            var victim = GetRandomThread();
+            if (victim.Id == workerData.Id)
+            {
+                // if we randomly choose ourselves we treat that as the master queue, and steal from there
+                if (MasterQueue.TryDequeue(out var stolen))
+                {
+                    task = stolen;
+                }
+            }
+            else
+            {
+                // Otherwise we steal from the victim!
+                StealFrom(out task, victim);
+            }
+            
+            // steal success!
+            if (task is not null) break;
+
+            // steal failed.
+            numFailedSteals++;
+            if (numFailedSteals >= _stealBound)
+            {
+                // if we've failed too many steals, we need to start yielding between steals.
+                Thread.Yield();
+                numYields++;
+                // if we've yielded too much, we give up completely and let WaitForTask decide whether to put us back to sleep (maybe)
+                if (numYields == _yieldBound) break;
+            }
+        }
+    }
+
+    private WorkerData GetRandomThread()
+    {
+        var worker = _random.Next(0, _workers.Length);
+        return _workers[worker];
+    }
+}

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -201,7 +201,10 @@ public partial class JobScheduler : IDisposable
                 _dependencyCache.Add(d.JobId);
             }
         }
-        if (dependency != null) _dependencyCache.Add(dependency.Value.JobId);
+        if (dependency != null)
+        {
+            _dependencyCache.Add(dependency.Value.JobId);
+        }
 
         JobId jobId;
         bool ready;
@@ -289,7 +292,10 @@ public partial class JobScheduler : IDisposable
             throw new InvalidOperationException($"Can only call {nameof(Flush)} from the thread that spawned the {nameof(JobScheduler)}!");
         }
 
-        if (QueuedJobs.Count == 0) return;
+        if (QueuedJobs.Count == 0)
+        {
+            return;
+        }
 
         // we only lock in debug mode for strict flushed-jobs checking within Complete()
 #if DEBUG

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -166,11 +166,6 @@ public partial class JobScheduler : IDisposable
     private List<JobMeta> QueuedJobs { get; }
 
     /// <summary>
-    /// Jobs flushed and waiting to be picked up by worker threads
-    /// </summary>
-    private ConcurrentQueue<JobMeta> MasterQueue { get; }
-
-    /// <summary>
     /// Tracks each job from scheduling to completion; when they complete, however, their data is removed from the pool and recycled.
     /// Note that we have to lock this, and can't use a ReaderWriterLock/ReaderWriterLockSlim because those allocate.
     /// </summary>

--- a/JobScheduler/JobScheduler.csproj
+++ b/JobScheduler/JobScheduler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         
@@ -28,7 +28,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.0" />
+        <PackageReference Include="DequeNET" Version="1.0.2" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.0" />
     </ItemGroup>
 
 

--- a/JobScheduler/JobScheduler.csproj
+++ b/JobScheduler/JobScheduler.csproj
@@ -28,7 +28,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DequeNET" Version="1.0.2" />
         <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Building on #19, this implements full work-stealing based on Lin et al and using a basic implementation of the Chase-Lev work-stealing deque (citations added in code if you want the links!)

I've observed this to be massively, massively faster than the original implementation we had: some tests had a speedup of ***12x***. But in-practice a lot of the overhead is stable, so the random graphs aren't hugely impacted.

Before:

| Method                | Threads | ConcurrentJobs | MaxConcurrentJobs | Waves | Mean       | Error    | StdDev   | Allocated |
|---------------------- |-------- |--------------- |------------------ |------ |-----------:|---------:|---------:|----------:|
| **BenchmarkSequential**   | **0**       | **32**             | **32**                | **1024**  |   **354.7 ms** |  **2.16 ms** |  **1.91 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 32                | 1024  |   119.4 ms |  1.94 ms |  1.82 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **32**             | **2048**              | **1024**  |   **359.4 ms** |  **3.60 ms** |  **2.81 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 2048              | 1024  |   124.8 ms |  0.72 ms |  0.67 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **128**            | **32**                | **1024**  | **1,422.3 ms** | **11.88 ms** | **11.11 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 32                | 1024  |   721.3 ms |  3.37 ms |  3.16 ms | 5532392 B |
| **BenchmarkSequential**   | **0**       | **128**            | **2048**              | **1024**  | **1,442.2 ms** | **13.98 ms** | **13.08 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 2048              | 1024  |   709.2 ms |  2.41 ms |  2.25 ms |     600 B |

Now:

| Method                | Threads | ConcurrentJobs | MaxConcurrentJobs | Waves | Mean      | Error     | StdDev    | Allocated |
|---------------------- |-------- |--------------- |------------------ |------ |----------:|----------:|----------:|----------:|
| **BenchmarkSequential**   | **0**       | **32**             | **32**                | **1024**  | **125.77 ms** |  **6.691 ms** | **19.729 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 32                | 1024  |  24.12 ms |  0.379 ms |  0.354 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **32**             | **2048**              | **1024**  | **144.08 ms** |  **0.845 ms** |  **0.706 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 32             | 2048              | 1024  |  23.80 ms |  0.147 ms |  0.122 ms |     600 B |
| **BenchmarkSequential**   | **0**       | **128**            | **32**                | **1024**  | **504.72 ms** | **25.878 ms** | **76.301 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 32                | 1024  | 125.66 ms |  0.474 ms |  0.444 ms | 5524920 B |
| **BenchmarkSequential**   | **0**       | **128**            | **2048**              | **1024**  | **575.46 ms** |  **4.129 ms** |  **3.448 ms** |     **600 B** |
| BenchmarkDependancies | 0       | 128            | 2048              | 1024  | 105.50 ms |  0.632 ms |  0.591 ms |     600 B |

Before:

| Method         | Threads | ConcurrentJobs | Waves | Degree | EdgeChance | Mean      | Error    | StdDev   | Allocated |
|--------------- |-------- |--------------- |------ |------- |----------- |----------:|---------:|---------:|----------:|
| **BenchmarkGraph** | **0**       | **32**             | **512**   | **4**      | **0.05**       |  **43.44 ms** | **0.847 ms** | **1.438 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **32**             | **512**   | **4**      | **0.2**        |  **42.44 ms** | **0.844 ms** | **1.798 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **128**            | **512**   | **4**      | **0.05**       | **169.77 ms** | **1.361 ms** | **1.273 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **128**            | **512**   | **4**      | **0.2**        | **172.12 ms** | **1.517 ms** | **1.419 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **256**            | **512**   | **4**      | **0.05**       | **410.01 ms** | **4.670 ms** | **4.368 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **256**            | **512**   | **4**      | **0.2**        | **446.24 ms** | **3.223 ms** | **3.014 ms** |     **600 B** |


Now:
| Method         | Threads | ConcurrentJobs | Waves | Degree | EdgeChance | Mean      | Error    | StdDev   | Allocated |
|--------------- |-------- |--------------- |------ |------- |----------- |----------:|---------:|---------:|----------:|
| **BenchmarkGraph** | **0**       | **32**             | **512**   | **4**      | **0.05**       |  **33.82 ms** | **0.619 ms** | **1.051 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **32**             | **512**   | **4**      | **0.2**        |  **33.18 ms** | **0.642 ms** | **0.812 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **128**            | **512**   | **4**      | **0.05**       | **171.29 ms** | **1.498 ms** | **1.402 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **128**            | **512**   | **4**      | **0.2**        | **160.22 ms** | **2.079 ms** | **1.944 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **256**            | **512**   | **4**      | **0.05**       | **395.60 ms** | **1.973 ms** | **1.845 ms** |     **600 B** |
| **BenchmarkGraph** | **0**       | **256**            | **512**   | **4**      | **0.2**        | **408.34 ms** | **5.583 ms** | **5.222 ms** |     **600 B** |

