### PR TITLE
Prepare for Arch upgrade

### DIFF
--- a/JobScheduler.Benchmarks/ParallelForBenchmark.cs
+++ b/JobScheduler.Benchmarks/ParallelForBenchmark.cs
@@ -69,6 +69,8 @@ public abstract class ParallelForBenchmark
         {
             _benchmark.Work(i);
         }
+
+        public void Finish() { }
     }
 
     private BasicParallelJob _basicParallel = null!;

--- a/JobScheduler.Test/ParallelJobTests.cs
+++ b/JobScheduler.Test/ParallelJobTests.cs
@@ -260,6 +260,11 @@ internal class ParallelJobTests : SchedulerTestFixture
                 Thread.Sleep(_sleep);
             }
         }
+
+        public void Finish()
+        {
+            Assert.That(ThreadIDs, Does.Not.Contain(0));
+        }
     }
 
     [TestCase(1024 * 1024, 0)]

--- a/JobScheduler.Test/Utils/ParallelTestJob.cs
+++ b/JobScheduler.Test/Utils/ParallelTestJob.cs
@@ -10,6 +10,8 @@ public class ParallelTestJob : IJobParallelFor
     public int ThreadCount { get; }
     public int BatchSize { get; }
 
+    public bool FinalizerRun { get; private set; } = false;
+
     private readonly int[] _array;
 
     public ParallelTestJob(int batchSize, int threadCount, int expectedSize)
@@ -24,6 +26,13 @@ public class ParallelTestJob : IJobParallelFor
         _array[index]++;
     }
 
+    public void Finish()
+    {
+        FinalizerRun = true;
+        AssertIsTotallyComplete();
+    }
+
+    [SuppressMessage("Assertion", "NUnit2045:Use Assert.Multiple", Justification = "<Pending>")]
     public void AssertIsTotallyIncomplete()
     {
         SearchArray(out var foundZeroValue, out var foundOneValue, out var foundOtherValue);
@@ -39,6 +48,7 @@ public class ParallelTestJob : IJobParallelFor
         Assert.That(foundZeroValue, Is.EqualTo(0));
         Assert.That(foundOneValue, Is.EqualTo(_array.Length));
         Assert.That(foundOtherValue, Is.EqualTo(0));
+        Assert.That(FinalizerRun, Is.True);
     }
 
     private void SearchArray(out int foundZeroValue, out int foundOneValue, out int foundOtherValue)
@@ -69,5 +79,7 @@ public class ParallelTestJob : IJobParallelFor
         {
             _array[i] = 0;
         }
+
+        FinalizerRun = false;
     }
 }

--- a/JobScheduler/Deque/CircularArray.cs
+++ b/JobScheduler/Deque/CircularArray.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Deque;
+﻿namespace Schedulers.Deque;
 
 /// <summary>
 /// A <see cref="CircularArray{T}"/> as found in Chase and Lev pg. 3 [1]

--- a/JobScheduler/Deque/RangeWorkStealingDeque.cs
+++ b/JobScheduler/Deque/RangeWorkStealingDeque.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Deque;
+﻿namespace Schedulers.Deque;
 
 /// <summary>
 ///     A <see cref="RangeWorkStealingDeque"/> is an implementation of the Chase &amp; Lev Dynamic Circular Work-Stealing Deque [1]

--- a/JobScheduler/Deque/WorkStealingDeque.cs
+++ b/JobScheduler/Deque/WorkStealingDeque.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Deque;
+﻿namespace Schedulers.Deque;
 
 /// <summary>
 ///     A <see cref="WorkStealingDeque{T}"/> is an implementation of the Chase &amp; Lev Dynamic Circular Work-Stealing Deque [1]

--- a/JobScheduler/IJob.cs
+++ b/JobScheduler/IJob.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler;
+﻿namespace Schedulers;
 
 /// <summary>
 ///     The <see cref="IJob"/> interface.

--- a/JobScheduler/IJobParallelFor.cs
+++ b/JobScheduler/IJobParallelFor.cs
@@ -48,4 +48,9 @@ public interface IJobParallelFor
     /// </summary>
     /// <param name="index"></param>
     public void Execute(int index);
+
+    /// <summary>
+    ///     Implement this method to provide custom code that executes once all parallel indices have been resolved.
+    /// </summary>
+    public void Finish();
 }

--- a/JobScheduler/IJobParallelFor.cs
+++ b/JobScheduler/IJobParallelFor.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler;
+﻿namespace Schedulers;
 
 /// <summary>
 ///     Represents a special job that, when scheduled, calls <see cref="Execute(int)"/> with every value of <c>index</c>.

--- a/JobScheduler/Job.cs
+++ b/JobScheduler/Job.cs
@@ -295,6 +295,12 @@ internal class Job
                     spin.SpinOnce();
                 }
             }
+
+            if (_masterJob.Value.Job == this)
+            {
+                // We're now sure everyone's completed.
+                _parallelWork.Finish();
+            }
         }
 
         // You may think that we have to manage parallel dependencies here, but actually we don't!

--- a/JobScheduler/Job.cs
+++ b/JobScheduler/Job.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Diagnostics;
-using JobScheduler.Deque;
+﻿using System.Diagnostics;
+using Schedulers.Deque;
 
-namespace JobScheduler;
+namespace Schedulers;
 
 /// <summary>
 ///     The <see cref="Job"/> struct
@@ -77,7 +76,7 @@ internal class Job
         _scheduler = scheduler;
         _dependents = new(dependentCapacity);
         _workerDeques = new RangeWorkStealingDeque[threadCapacity];
-        for (int i = 0; i < threadCapacity; i++)
+        for (var i = 0; i < threadCapacity; i++)
         {
             _workerDeques[i] = new();
         }

--- a/JobScheduler/JobHandle.cs
+++ b/JobScheduler/JobHandle.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-namespace JobScheduler;
+namespace Schedulers;
 
 /// <summary>
 ///     The <see cref="JobHandle"/> struct

--- a/JobScheduler/JobScheduler.WorkStealing.cs
+++ b/JobScheduler/JobScheduler.WorkStealing.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Concurrent;
-using JobScheduler.Deque;
+using Schedulers.Deque;
 
-namespace JobScheduler;
+namespace Schedulers;
 
 // This section of JobScheduler deals with the implementation of the Lin et al. algorithm [1]. 
 // It is compartmentalized into a separate partial, so that it can express the paper's algorithm as clearly and readably as possible,

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -170,9 +170,9 @@ public partial class JobScheduler : IDisposable
     private List<Job> QueuedJobs { get; }
 
     /// <summary>
-    /// Returns whether this is the main thread the scheduler was created on
+    /// Returns true if this is the main thread the scheduler was created on; false otherwise
     /// </summary>
-    private bool IsMainThread
+    public bool IsMainThread
     {
         get => Thread.CurrentThread.ManagedThreadId == MainThreadID;
     }

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(true)]
 
-namespace JobScheduler;
+namespace Schedulers;
 
 /// <summary>
 ///     A <see cref="JobScheduler"/> schedules and processes <see cref="IJob"/>s asynchronously. Better-suited for larger jobs due to its underlying events. 

--- a/JobScheduler/XorshiftRandom.cs
+++ b/JobScheduler/XorshiftRandom.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace JobScheduler;
+﻿namespace Schedulers;
 
 /// <summary>
 /// A super-fast pseudo-random number generator.


### PR DESCRIPTION
A few changes are necessary to get the scheduler ready-to-go for Arch.

Of note, JobScheduler namespace is changed to Schedulers.

Also, I added a `Finish()` method to `IJobParallelFor`. This allows a job to do its own cleanup work without having to schedule a whole second job to do so.