### PR TITLE
Fix namespace bug

### DIFF
--- a/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/ManyJobsBenchmark.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Benchmarks;
+﻿namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Benchmark adding a ton of jobs to the queue, flushing, and then completing them.

--- a/JobScheduler.Benchmarks/MaxConcurrentJobsBenchmark.cs
+++ b/JobScheduler.Benchmarks/MaxConcurrentJobsBenchmark.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Benchmarks;
+﻿namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Benchmark the overhead of increasing the <see cref="JobScheduler.Config.MaxExpectedConcurrentJobs"/> without changing the total amount of jobs run.

--- a/JobScheduler.Benchmarks/ParallelForBenchmark.cs
+++ b/JobScheduler.Benchmarks/ParallelForBenchmark.cs
@@ -1,6 +1,6 @@
 ﻿using Arch.Benchmarks;
 
-namespace JobScheduler.Benchmarks;
+namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Benchmark adding a ton of jobs to the queue, flushing, and then completing them.

--- a/JobScheduler.Benchmarks/ParallelForBenchmarkMatrix.cs
+++ b/JobScheduler.Benchmarks/ParallelForBenchmarkMatrix.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Benchmarks;
+﻿namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Increments a simple counter as the work;

--- a/JobScheduler.Benchmarks/ParallelForBenchmarkSimple.cs
+++ b/JobScheduler.Benchmarks/ParallelForBenchmarkSimple.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Benchmarks;
+﻿namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Increments a simple counter as the work;

--- a/JobScheduler.Benchmarks/QueueBenchmark.cs
+++ b/JobScheduler.Benchmarks/QueueBenchmark.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Benchmarks;
+﻿namespace Schedulers.Benchmarks;
 
 [MemoryDiagnoser]
 public class QueueBenchmark

--- a/JobScheduler.Benchmarks/RandomGraphBenchmark.cs
+++ b/JobScheduler.Benchmarks/RandomGraphBenchmark.cs
@@ -1,7 +1,7 @@
-﻿using JobScheduler.Benchmarks.Utils.Graph;
+﻿using Schedulers.Benchmarks.Utils.Graph;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace JobScheduler.Benchmarks;
+namespace Schedulers.Benchmarks;
 
 /// <summary>
 /// Benchmark adding a ton of jobs to the queue, flushing, and then completing them.

--- a/JobScheduler.Benchmarks/Schedulers.Benchmarks.csproj
+++ b/JobScheduler.Benchmarks/Schedulers.Benchmarks.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\JobScheduler\JobScheduler.csproj" />
+    <ProjectReference Include="..\JobScheduler\Schedulers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/JobScheduler.Benchmarks/Utils/Graph/DirectedAcyclicGraph.cs
+++ b/JobScheduler.Benchmarks/Utils/Graph/DirectedAcyclicGraph.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace JobScheduler.Benchmarks.Utils.Graph;
+namespace Schedulers.Benchmarks.Utils.Graph;
 
 public class DirectedAcyclicGraph
 {

--- a/JobScheduler.Benchmarks/Utils/Graph/GraphGenerator.cs
+++ b/JobScheduler.Benchmarks/Utils/Graph/GraphGenerator.cs
@@ -1,6 +1,6 @@
-﻿using static JobScheduler.Benchmarks.Utils.Graph.DirectedAcyclicGraph;
+﻿using static Schedulers.Benchmarks.Utils.Graph.DirectedAcyclicGraph;
 
-namespace JobScheduler.Benchmarks.Utils.Graph;
+namespace Schedulers.Benchmarks.Utils.Graph;
 
 public class GraphGenerator
 {

--- a/JobScheduler.Test/AllocationTests.cs
+++ b/JobScheduler.Test/AllocationTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using JobScheduler.Test.Utils;
-using JobScheduler.Test.Utils.CustomConstraints;
+using Schedulers.Test.Utils;
+using Schedulers.Test.Utils.CustomConstraints;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 [SuppressMessage("Assertion", "NUnit2045:Use Assert.Multiple",
     Justification = "Multiple asserts are not appropriate as later code")]

--- a/JobScheduler.Test/BenchmarkTests/GraphGeneratorTests.cs
+++ b/JobScheduler.Test/BenchmarkTests/GraphGeneratorTests.cs
@@ -1,7 +1,7 @@
-﻿using JobScheduler.Benchmarks.Utils.Graph;
+﻿using Schedulers.Benchmarks.Utils.Graph;
 using System.Diagnostics;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 [TestFixture]
 internal class GraphGeneratorTests

--- a/JobScheduler.Test/CombineDependenciesTests.cs
+++ b/JobScheduler.Test/CombineDependenciesTests.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Test.Utils;
+﻿using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 internal class CombineDependenciesTests : SchedulerTestFixture
 {

--- a/JobScheduler.Test/CompleteTests.cs
+++ b/JobScheduler.Test/CompleteTests.cs
@@ -1,6 +1,6 @@
-using JobScheduler.Test.Utils;
+using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 internal class CompleteTests : SchedulerTestFixture
 {

--- a/JobScheduler.Test/JobSchedulerTests.cs
+++ b/JobScheduler.Test/JobSchedulerTests.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Test.Utils;
+﻿using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 internal class JobSchedulerTests : SchedulerTestFixture
 {

--- a/JobScheduler.Test/ParallelJobTests.cs
+++ b/JobScheduler.Test/ParallelJobTests.cs
@@ -1,10 +1,10 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using BenchmarkDotNet.Jobs;
-using JobScheduler.Test.Utils;
-using JobScheduler.Test.Utils.CustomConstraints;
+using Schedulers.Test.Utils;
+using Schedulers.Test.Utils.CustomConstraints;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 [SuppressMessage("Assertion", "NUnit2045:Use Assert.Multiple",
     Justification = "Multiple asserts are not appropriate as later code")]

--- a/JobScheduler.Test/QueueAllocationTests.cs
+++ b/JobScheduler.Test/QueueAllocationTests.cs
@@ -1,7 +1,7 @@
-﻿using JobScheduler.Test.Utils.CustomConstraints;
+﻿using Schedulers.Test.Utils.CustomConstraints;
 using System.Collections.Concurrent;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 [TestFixture]
 internal class QueueAllocationTests

--- a/JobScheduler.Test/RangeWorkStealingDequeTests.cs
+++ b/JobScheduler.Test/RangeWorkStealingDequeTests.cs
@@ -4,9 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using JobScheduler.Deque;
+using Schedulers.Deque;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 [TestFixture]
 internal class RangeWorkStealingDequeTests
 {

--- a/JobScheduler.Test/Schedulers.Test.csproj
+++ b/JobScheduler.Test/Schedulers.Test.csproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\JobScheduler\JobScheduler.csproj" />
-		<ProjectReference Include="..\JobScheduler.Benchmarks\JobScheduler.Benchmarks.csproj" />
+      <ProjectReference Include="..\JobScheduler\Schedulers.csproj" />
+		<ProjectReference Include="..\JobScheduler.Benchmarks\Schedulers.Benchmarks.csproj" />
     </ItemGroup>
 
 </Project>

--- a/JobScheduler.Test/SingleDependencyTests.cs
+++ b/JobScheduler.Test/SingleDependencyTests.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Test.Utils;
+﻿using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 internal partial class SingleDependencyTests : SchedulerTestFixture
 {

--- a/JobScheduler.Test/StressTests.cs
+++ b/JobScheduler.Test/StressTests.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Test.Utils;
+﻿using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 [TestFixture(0, 32)]
 [TestFixture(1, 32)]
 [TestFixture(2, 32)]

--- a/JobScheduler.Test/Usings.cs
+++ b/JobScheduler.Test/Usings.cs
@@ -1,2 +1,2 @@
 ﻿global using NUnit.Framework;
-global using Is = JobScheduler.Test.Utils.CustomConstraints.Is;
+global using Is = Schedulers.Test.Utils.CustomConstraints.Is;

--- a/JobScheduler.Test/Utils/ActionJob.cs
+++ b/JobScheduler.Test/Utils/ActionJob.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Test.Utils;
+﻿using Schedulers.Test.Utils;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 /// <summary>
 /// A <see cref="TestJob"/> that runs an arbitrary action before incrementing its <see cref="TestJob.Result"/>

--- a/JobScheduler.Test/Utils/CustomConstraints/AllocatingMemoryConstraint.cs
+++ b/JobScheduler.Test/Utils/CustomConstraints/AllocatingMemoryConstraint.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework.Constraints;
 
-namespace JobScheduler.Test.Utils.CustomConstraints;
+namespace Schedulers.Test.Utils.CustomConstraints;
 
 /// <summary>
 /// Ensures that the provided lambda is allocating GC memory

--- a/JobScheduler.Test/Utils/GraphRunner.cs
+++ b/JobScheduler.Test/Utils/GraphRunner.cs
@@ -1,6 +1,6 @@
-﻿using JobScheduler.Benchmarks.Utils.Graph;
+﻿using Schedulers.Benchmarks.Utils.Graph;
 
-namespace JobScheduler.Test.Utils;
+namespace Schedulers.Test.Utils;
 internal static class GraphRunner
 {
     /// <summary>

--- a/JobScheduler.Test/Utils/ParallelTestJob.cs
+++ b/JobScheduler.Test/Utils/ParallelTestJob.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace JobScheduler.Test.Utils;
+namespace Schedulers.Test.Utils;
 
 /// <summary>
 /// A <see cref="IJobParallelFor"/> that stores an internal array that can be tested against for validation.

--- a/JobScheduler.Test/Utils/SchedulerTestFixture.cs
+++ b/JobScheduler.Test/Utils/SchedulerTestFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Test.Utils;
+﻿namespace Schedulers.Test.Utils;
 
 // run the fixture with multiple thread configurations
 [TestFixture(0)]

--- a/JobScheduler.Test/Utils/SleepJob.cs
+++ b/JobScheduler.Test/Utils/SleepJob.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Test.Utils;
+﻿namespace Schedulers.Test.Utils;
 
 /// <summary>
 /// A <see cref="TestJob"/> that sleeps before incrementing its result.

--- a/JobScheduler.Test/Utils/TestJob.cs
+++ b/JobScheduler.Test/Utils/TestJob.cs
@@ -1,4 +1,4 @@
-﻿namespace JobScheduler.Test.Utils;
+﻿namespace Schedulers.Test.Utils;
 
 /// <summary>
 /// A test job that increments <see cref="Result"/> when executed.

--- a/JobScheduler.Test/XorshiftRandomTests.cs
+++ b/JobScheduler.Test/XorshiftRandomTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace JobScheduler.Test;
+namespace Schedulers.Test;
 
 [TestFixture]
 internal class XorshiftRandomTests

--- a/JobScheduler.sln
+++ b/JobScheduler.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler", "JobScheduler\JobScheduler.csproj", "{96AB1B0E-2501-4972-BECA-690878DB5852}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Schedulers", "JobScheduler\Schedulers.csproj", "{96AB1B0E-2501-4972-BECA-690878DB5852}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler.Test", "JobScheduler.Test\JobScheduler.Test.csproj", "{22CA05F3-3921-4DEE-BC02-392BBC7F885C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Schedulers.Test", "JobScheduler.Test\Schedulers.Test.csproj", "{22CA05F3-3921-4DEE-BC02-392BBC7F885C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler.Benchmarks", "JobScheduler.Benchmarks\JobScheduler.Benchmarks.csproj", "{1C11086C-D170-41A9-BDC3-76F4D617A607}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Schedulers.Benchmarks", "JobScheduler.Benchmarks\Schedulers.Benchmarks.csproj", "{1C11086C-D170-41A9-BDC3-76F4D617A607}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DA3563CE-1A5E-4324-B8AF-461C7B9D5CD4}"
 	ProjectSection(SolutionItems) = preProject

--- a/JobScheduler/Schedulers.csproj
+++ b/JobScheduler/Schedulers.csproj
@@ -29,7 +29,7 @@
     
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>JobScheduler.Test</_Parameter1>
+			<_Parameter1>Schedulers.Test</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
 


### PR DESCRIPTION
There was a bug with the namespace change that caused some build errors with the benchmark.

This fixes that.