### PR TITLE
Make JobHandle pure struct for stackalloc compatibility

### DIFF
--- a/JobScheduler/JobHandle.cs
+++ b/JobScheduler/JobHandle.cs
@@ -9,34 +9,136 @@ namespace Schedulers;
 public readonly struct JobHandle : IEquatable<JobHandle>
 {
     /// <summary>
-    ///     Creates a new <see cref="JobHandle"/> instance.
+    ///     Assigns schedulers an ID, and a cache of tracked jobs.
+    ///     This way, we can store a Scheduler and a Job on a JobHandle by integer ID,
+    ///     so that stackalloc JobHandle[] can work. Otherwise the managed types would prevent it.
     /// </summary>
-    /// <param name="scheduler">The <see cref="JobScheduler"/>.</param>
-    /// <param name="version">The current version of the job.</param>
-    /// <param name="job">The job to assciate with this handle.</param>
-    internal JobHandle(JobScheduler scheduler, int version, Job job)
+    // A dictionary is OK because we only add when we initialize a new scheduler.
+    // It otherwise doesn't use memory.
+    // Accesses could be sliiiightly faster if we used an array and recycled IDs but not appreciably so,
+    // particularly for the overhead it would involve.
+    private static readonly Dictionary<int, (JobScheduler Scheduler, Job[] JobIds)>
+        _schedulerCache = [];
+
+    /// <summary>
+    ///     Initialize a new Scheduler with the handle-recycling system. Will spontaneously allocate.
+    /// </summary>
+    /// <param name="schedulerId">
+    ///     The ID of the scheduler. Must be unique per scheduler instance, and must never
+    ///     be recycled.
+    /// </param>
+    /// <param name="scheduler">The scheduler object.</param>
+    /// <param name="jobsCount">The number of jobs to </param>
+    internal static void InitializeScheduler(int schedulerId, JobScheduler scheduler, int jobsCount)
     {
-        Version = version;
-        Scheduler = scheduler;
-        Job = job;
+        lock (_schedulerCache)
+        {
+            _schedulerCache[schedulerId] = (scheduler, new Job[jobsCount]);
+        }
     }
 
     /// <summary>
-    ///     The <see cref="JobScheduler"/> used by this scheduled job.
+    ///     Track a newly-created job with the handle-recycling system. Will spontaneously allocate.
     /// </summary>
-    internal JobScheduler Scheduler { get; }
+    /// <param name="schedulerId">The ID of the scheduler to track jobs for.</param>
+    /// <param name="job">The job object to track.</param>
+    internal static void TrackJob(int schedulerId, Job job)
+    {
+        lock (_schedulerCache)
+        {
+            var cache = _schedulerCache[schedulerId];
+            if (job.InstanceId >= cache.JobIds.Length)
+            {
+                Array.Resize(ref cache.JobIds, cache.JobIds.Length * 2);
+                _schedulerCache[schedulerId] = cache;
+            }
+
+            cache.JobIds[job.InstanceId] = job;
+        }
+    }
 
     /// <summary>
-    ///     The <see cref="Job"/> that was associated with the handle on creation.
+    ///     Remove a scheduler, and all tracked job IDs.
+    ///     This will invalidate all existing handles; any methods on them will be invalid.
+    /// </summary>
+    /// <param name="id"></param>
+    internal static void DisposeScheduler(int id)
+    {
+        lock (_schedulerCache)
+        {
+            _schedulerCache.Remove(id);
+        }
+    }
+
+    /// <summary>
+    ///     Creates a new <see cref="JobHandle"/> instance.
+    /// </summary>
+    /// <param name="schedulerId">The <see cref="JobScheduler"/> instance ID.</param>
+    /// <param name="version">The current version of the job.</param>
+    /// <param name="jobId">The job to assciate with this handle.</param>
+    internal JobHandle(int schedulerId, int version, long jobId)
+    {
+        Version = version;
+        SchedulerId = schedulerId;
+        JobId = jobId;
+    }
+
+    /// <summary>
+    ///     The <see cref="JobScheduler"/> used by this scheduled job, as tracked by the ID system.
+    /// </summary>
+    internal int SchedulerId { get; }
+
+    /// <summary>
+    ///     The <see cref="Job"/> that was associated with the handle on creation, as tracked by the
+    ///     ID system.
     ///     May not be the current job, if the version is expired.
     /// </summary>
-    internal Job Job { get; }
+    internal long JobId { get; }
 
     /// <summary>
     ///     The job version used by this scheduled job. If this doesn't match <see cref="Job"/>, it means
-    ///     the job is completed.
+    ///     the job is completed and the original object was recycled.
     /// </summary>
     internal int Version { get; }
+
+    internal JobScheduler Scheduler
+    {
+        get
+        {
+            lock (_schedulerCache)
+            {
+                if (!_schedulerCache.TryGetValue(SchedulerId, out var foundScheduler))
+                {
+                    throw new InvalidOperationException($"Cannot process a job handle from a disposed scheduler!");
+                }
+
+                return foundScheduler.Scheduler;
+            }
+        }
+    }
+
+    internal Job Job
+    {
+        get
+        {
+            lock (_schedulerCache)
+            {
+                if (!_schedulerCache.TryGetValue(SchedulerId, out var foundScheduler))
+                {
+                    throw new InvalidOperationException($"Cannot process a job handle from a disposed scheduler!");
+                }
+
+                var jobIds = foundScheduler.JobIds;
+
+                if (JobId >= jobIds.Length)
+                {
+                    throw new InvalidOperationException($"Job ID not tracked!");
+                }
+
+                return jobIds[JobId];
+            }
+        }
+    }
 
     /// <summary>
     ///     Waits for the <see cref="JobHandle"/> to complete.
@@ -82,15 +184,15 @@ public readonly struct JobHandle : IEquatable<JobHandle>
     /// <inheritdoc/>
     public bool Equals(JobHandle other)
     {
-        return EqualityComparer<JobScheduler>.Default.Equals(Scheduler, other.Scheduler) &&
-               EqualityComparer<Job>.Default.Equals(Job, other.Job) &&
+        return SchedulerId == other.SchedulerId &&
+               JobId == other.JobId &&
                Version == other.Version;
     }
 
     /// <inheritdoc/>
     public override int GetHashCode()
     {
-        return HashCode.Combine(Scheduler, Job, Version);
+        return HashCode.Combine(SchedulerId, JobId, Version);
     }
 
     /// <inheritdoc/>

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -82,12 +82,22 @@ public partial class JobScheduler : IDisposable
     // a pool for recyling managed Jobs
     private readonly ConcurrentQueue<Job> _jobPool;
 
+    private static int _lastInstanceId = -1;
+
+    /// <summary>
+    ///     A unique ID for this particular Scheduler
+    /// </summary>
+    internal int InstanceId { get; }
+
+    private int _lastJobId = -1;
+
     /// <summary>
     /// Creates an instance of the <see cref="JobScheduler"/>
     /// </summary>
     /// <param name="settings">The <see cref="Config"/> to use for this instance of <see cref="JobScheduler"/></param>
     public JobScheduler(in Config settings)
     {
+        InstanceId = Interlocked.Increment(ref _lastInstanceId);
         MainThreadID = Thread.CurrentThread.ManagedThreadId;
 
         ThreadCount = settings.ThreadCount;
@@ -99,6 +109,8 @@ public partial class JobScheduler : IDisposable
         _strictAllocationMode = settings.StrictAllocationMode;
         _maxConcurrentJobs = settings.MaxExpectedConcurrentJobs;
         _dependencyCache = new(settings.MaxExpectedConcurrentJobs - 1);
+
+        JobHandle.InitializeScheduler(InstanceId, this, _maxConcurrentJobs);
 
         // pre-fill all of our data structures up to the concurrent job max
         QueuedJobs = new(settings.MaxExpectedConcurrentJobs);
@@ -134,7 +146,8 @@ public partial class JobScheduler : IDisposable
         for (var i = 0; i < settings.MaxExpectedConcurrentJobs; i++)
         {
             // this will automatically pool
-            new Job(settings.MaxExpectedConcurrentJobs - 1, ThreadCount, this);
+            var j = new Job(settings.MaxExpectedConcurrentJobs - 1, ThreadCount, this, Interlocked.Increment(ref _lastJobId));
+            JobHandle.TrackJob(InstanceId, j);
         }
 
         InitAlgorithm(ThreadCount, _maxConcurrentJobs, CancellationTokenSource.Token);
@@ -189,7 +202,8 @@ public partial class JobScheduler : IDisposable
             }
             // We are spontaneously allocating, so to save memory, don't use an initial size
             // This will automatically pool!
-            new Job(0, ThreadCount, this);
+            var j = new Job(0, ThreadCount, this, Interlocked.Increment(ref _lastJobId));
+            JobHandle.TrackJob(InstanceId, j);
         }
 
         return job;
@@ -392,12 +406,13 @@ public partial class JobScheduler : IDisposable
     /// </summary>
     /// <param name="handle"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void Complete(JobHandle handle)
+    internal void Complete(in JobHandle handle)
     {
-        if (handle.Job.TrySubscribe(handle.Version, out var waitHandle))
+        var job = handle.Job;
+        if (job.TrySubscribe(handle.Version, out var waitHandle))
         {
             waitHandle.WaitOne();
-            handle.Job.Unsubscribe(handle.Version);
+            job.Unsubscribe(handle.Version);
         }
     }
 
@@ -430,5 +445,7 @@ public partial class JobScheduler : IDisposable
         // either this works and threads are signalled to go into shutdown mode, which eventually dispose..
         // or they somehow managed to 100% shutdown and dispose already, in which case his does nothing.
         _notifier.NotifyAll();
+
+        JobHandle.DisposeScheduler(InstanceId);
     }
 }


### PR DESCRIPTION
Resolves #31 by adding a caching system to associate Job and Scheduler classes to a JobHandle that just stores integer IDs.

Ran a few benchmarks; no significant performance impact; it only has to do a couple extra dictionary/array lookups per Schedule and Complete call.