### PR TITLE
Actually fix IJobParallelFor

### DIFF
--- a/JobScheduler.Benchmarks/ParallelForBenchmarkMatrix.cs
+++ b/JobScheduler.Benchmarks/ParallelForBenchmarkMatrix.cs
@@ -1,6 +1,5 @@
 ﻿namespace Schedulers.Benchmarks;
 
-
 /// <summary>
 /// Increments a simple counter as the work;
 /// </summary>
@@ -43,9 +42,28 @@ public class ParallelForBenchmarkMatrix : ParallelForBenchmark
         var col = index % _dim;
         float sum = 0;
 
-        for (var k = 0; k < _dim; k++)
+        // test more complicated work as indices get higher to test work stealing
+        var reps = 0;
+        if (index < Size / 3)
         {
-            sum += _matrixA[(row * _dim) + k] * _matrixB[(k * _dim) + col];
+            reps = 1;
+        }
+        else if (index < Size / 3 * 2)
+        {
+            reps = 3;
+        }
+        else
+        {
+            reps = 6;
+        }
+
+        for (var i = 0; i < reps; i++)
+        {
+            sum = 0;
+            for (var k = 0; k < _dim; k++)
+            {
+                sum += _matrixA[(row * _dim) + k] * _matrixB[(k * _dim) + col];
+            }
         }
 
         _matrixC[index] = sum;

--- a/JobScheduler/JobScheduler.cs
+++ b/JobScheduler/JobScheduler.cs
@@ -305,9 +305,12 @@ public partial class JobScheduler : IDisposable
     ///     Note that this will schedule as many jobs as specified in <see cref="IJobParallelFor"/> or the maximum thread count, whichever is less
     ///     (or the maximum thread count if the threads provided are 0). See <see cref="IJobParallelFor"/> for details.
     /// </remarks>
-    /// <param name="job"></param>
-    /// <param name="amount"></param>
-    /// <param name="dependency"></param>
+    /// <param name="job">The <see cref="IJobParallelFor"/> to schedule.</param>
+    /// <param name="amount">
+    ///     The amount of indices to execute.
+    ///     <see cref="IJobParallelFor.Execute(int)"/> will be called for each value in <c>[0, <paramref name="amount"/>)</c>.
+    /// </param>
+    /// <param name="dependency">A <see cref="JobHandle"/> dependency to require completion of first.</param>
     /// <returns>The <see cref="JobHandle"/> of a job representing the full task.</returns>
     /// <exception cref="InvalidOperationException">If called on a different thread than the <see cref="JobScheduler"/> was constructed on</exception>
     /// <exception cref="MaximumConcurrentJobCountExceededException">If the maximum amount of concurrent jobs is at maximum, and strict mode is enabled.</exception>


### PR DESCRIPTION
Turns out the issue was a simple one: The big performance discrepancies I was seeing was due to an extra CAS operation in the work stealing algorithm. It now works on the level of C#'s inbuilt `Parallel.For`, and is faster than the naive solution in non-ideal cases (the naive solution is still sliiiiiightly faster in ideal circumstances due to less overhead but not appreciably).

This repo also adds documentation to README.md and fixes #30 by documenting `amount`.