### PR TITLE
Fix deadlock and reduce allocations

### DIFF
--- a/JobScheduler.Benchmarks/Benchmark.cs
+++ b/JobScheduler.Benchmarks/Benchmark.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.CsProj;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
@@ -8,35 +9,130 @@ using Schedulers.Utils;
 
 namespace Arch.Benchmarks;
 
+public class HeavyCalculationJob : IJob
+{
+    private double _first;
+    private double _second;
+
+    public HeavyCalculationJob(int first, int second)
+    {
+        _first = first;
+        _second = second;
+    }
+
+    public void Execute()
+    {
+        for (var i = 0; i < 2000; i++)
+        {
+            _first = double.Sqrt(_second);
+            _second = double.Sqrt(_first) + 1;
+        }
+    }
+}
+
 public class Benchmark
 {
+    private static void BenchA()
+    {
+        var timer = Stopwatch.StartNew();
+        using var jobScheduler = new JobScheduler();
+        for (var sindex = 0; sindex < 100; sindex++)
+        {
+            var generation = jobScheduler.GetNewGeneration();
+            for (var index = 0; index < 20000; index++)
+            {
+                var job = new HeavyCalculationJob(index, index);
+                jobScheduler.ScheduleAndFlushPooledJobWithGeneration(job, generation);
+            }
+
+            jobScheduler.AwaitForGeneration(generation);
+        }
+
+        var time = timer.ElapsedMilliseconds;
+        Console.WriteLine($"Time: {time}ms");
+    }
+
+    private static void BenchB()
+    {
+        using var jobScheduler = new JobScheduler();
+        var timer = Stopwatch.StartNew();
+        for (var sindex = 0; sindex < 100; sindex++)
+        {
+            List<JobHandle> _jobHandles = new();
+            for (var index = 0; index < 20000; index++)
+            {
+                var job = new HeavyCalculationJob(index, index);
+                var handle = jobScheduler.Schedule(job);
+                _jobHandles.Add(handle);
+            }
+
+            jobScheduler.Flush(_jobHandles.AsSpan());
+            jobScheduler.Wait(_jobHandles.AsSpan());
+        }
+
+        var time = timer.ElapsedMilliseconds;
+        Console.WriteLine($"Job scheduler Time: {time}ms");
+    }
+
+    private static void BenchC()
+    {
+        var timer = Stopwatch.StartNew();
+        for (var sindex = 0; sindex < 100; sindex++)
+        {
+            var list = new List<HeavyCalculationJob>();
+            for (var index = 0; index < 20000; index++)
+            {
+                var job = new HeavyCalculationJob(index, index);
+                list.Add(job);
+            }
+
+            Parallel.ForEach(list, job => job.Execute());
+        }
+
+        var time = timer.ElapsedMilliseconds;
+        Console.WriteLine($"Parallel foreach Time: {time}ms");
+    }
+
+    private static void BenchD()
+    {
+        var timer = Stopwatch.StartNew();
+        for (var sindex = 0; sindex < 100; sindex++)
+        {
+            Parallel.For(0, 20000, i =>
+            {
+                var job = new HeavyCalculationJob(i, i);
+                job.Execute();
+            });
+        }
+
+        var time = timer.ElapsedMilliseconds;
+        Console.WriteLine($"Parallel for Time: {time}ms");
+    }
+
     private static void Main(string[] args)
     {
         var config = DefaultConfig.Instance.AddJob(Job.Default
-                .WithWarmupCount(2)    // Anzahl der Warmup-Runden
-                .WithIterationCount(10) // Iterationen pro Benchmark
-                .WithMaxIterationCount(50) // Max. Iterationen
+            .WithWarmupCount(2)
+            .WithMinIterationCount(10)
+            .WithIterationCount(20)
+            .WithMaxIterationCount(30)
+            // .WithAffinity(65535)//To not freeze my pc
         );
-
-        for (var sindex = 0; sindex < 1_000; sindex++)
+        config = config.WithOptions(ConfigOptions.DisableOptimizationsValidator);
+        BenchmarkRunner.Run<JobSchedulerBenchmark>(config);
+        return;
+        // var jb = new JobSchedulerBenchmark();
+        // jb.Setup();
+        // jb.Jobs = 512;
+        // jb.BenchmarkJobSchedulerNoAlloc();
+        // jb.Cleanup();
+        // return;
+        for (int i = 0; i < 10; i++)
         {
-            var jobScheduler = new JobScheduler();
-            var handles = new List<JobHandle>(100);
-
-            for (var index = 0; index < 18; index++)
-            {
-                var job = new CalculationJob(index, index);
-                var handle = jobScheduler.Schedule(job);
-                handles.Add(handle);
-                Console.WriteLine($"Handle {index} scheduled");
-            }
-
-            jobScheduler.Flush(handles.AsSpan());
-            jobScheduler.Wait(handles.AsSpan());
-            Console.WriteLine($"{sindex} done");
-            jobScheduler.Dispose();
+            BenchB();
+            BenchC();
+            BenchD();
         }
-
         //using var jobScheduler = new JobScheduler();
 
         // Spawn massive jobs and wait for finish

--- a/JobScheduler.Benchmarks/Benchmark.cs
+++ b/JobScheduler.Benchmarks/Benchmark.cs
@@ -111,16 +111,16 @@ public class Benchmark
 
     private static void Main(string[] args)
     {
-        var config = DefaultConfig.Instance.AddJob(Job.Default
-            .WithWarmupCount(2)
-            .WithMinIterationCount(10)
-            .WithIterationCount(20)
-            .WithMaxIterationCount(30)
-            // .WithAffinity(65535)//To not freeze my pc
-        );
-        config = config.WithOptions(ConfigOptions.DisableOptimizationsValidator);
-        BenchmarkRunner.Run<JobSchedulerBenchmark>(config);
-        return;
+        // var config = DefaultConfig.Instance.AddJob(Job.Default
+        //     .WithWarmupCount(2)
+        //     .WithMinIterationCount(10)
+        //     .WithIterationCount(20)
+        //     .WithMaxIterationCount(30)
+        //     // .WithAffinity(65535)//To not freeze my pc
+        // );
+        // config = config.WithOptions(ConfigOptions.DisableOptimizationsValidator);
+        // BenchmarkRunner.Run<JobSchedulerBenchmark>(config);
+        // return;
         // var jb = new JobSchedulerBenchmark();
         // jb.Setup();
         // jb.Jobs = 512;
@@ -130,8 +130,8 @@ public class Benchmark
         for (int i = 0; i < 10; i++)
         {
             BenchB();
-            BenchC();
-            BenchD();
+            // BenchC();
+            // BenchD();
         }
         //using var jobScheduler = new JobScheduler();
 

--- a/JobScheduler/Utils/JobHandlePool.cs
+++ b/JobScheduler/Utils/JobHandlePool.cs
@@ -1,0 +1,82 @@
+namespace Schedulers.Utils;
+
+internal class JobHandlePool
+{
+    public readonly JobHandle[] _handles;
+    private readonly bool[] _isFree;
+    private readonly Queue<int> _freeHandles;
+    private int _returnedHandles;
+    public int Generation;
+
+    public JobHandlePool(int size)
+    {
+        _freeHandles = new(size);
+        _handles = new JobHandle[size];
+        _isFree = new bool[size];
+
+        for (var i = 0; i < size; i++)
+        {
+            _handles[i] = new(i);
+            _freeHandles.Enqueue(i);
+            _isFree[i] = true;
+        }
+    }
+
+    private void CleanupHandles()
+    {
+        // Prevent cleanup if no handles were returned
+        // This is a guard to prevent cleanup every time someone tries to get a handle, in a tight loop
+        if (_returnedHandles == 0)
+        {
+            return;
+        }
+
+        _freeHandles.Clear();
+        for (var i = 0; i < _isFree.Length; i++)
+        {
+            if (_isFree[i])
+            {
+                _freeHandles.Enqueue(i);
+            }
+        }
+
+        _returnedHandles = 0;
+    }
+
+    // Not intrinsically thread safe so we lock
+    // Assumption is that the user won't generate handles on other threads
+    internal bool GetHandle(out JobHandle? handle)
+    {
+        // lock (this)
+        {
+            if (_freeHandles.Count == 0)
+            {
+                CleanupHandles();
+            }
+
+            if (_freeHandles.Count == 0)
+            {
+                handle = null;
+                return false;
+            }
+
+            var index = _freeHandles.Dequeue();
+            _isFree[index] = false;
+            handle = _handles[index];
+            return true;
+        }
+    }
+
+    //Thread safe
+    internal void ReturnHandle(JobHandle handle)
+    {
+        // It means the handle is not ours
+        if (handle.index == -1)
+        {
+            return;
+        }
+
+        _isFree[handle.index] = true;
+        _returnedHandles++; // We don't care about thread safety here
+    }
+}

--- a/JobScheduler/Utils/JobSchedulerExtensions.cs
+++ b/JobScheduler/Utils/JobSchedulerExtensions.cs
@@ -11,10 +11,7 @@ public static class JobSchedulerExtensions
     {
         foreach (ref var job in jobs)
         {
-            // Round Robin distribution
-            var workerIndex = jobScheduler.NextWorkerIndex;
-            jobScheduler.Workers[workerIndex].IncomingQueue.TryEnqueue(job);
-            jobScheduler.NextWorkerIndex = (jobScheduler.NextWorkerIndex + 1) % jobScheduler.Workers.Count;
+            jobScheduler.Flush(job);
         }
     }
 

--- a/JobScheduler/Utils/UnorderedQueue.cs
+++ b/JobScheduler/Utils/UnorderedQueue.cs
@@ -1,72 +1,32 @@
+using System.Collections.Concurrent;
+
 namespace Schedulers.Utils;
-
-public class SimpleQueue<T>
-{
-    public T[] data;
-    public int enqueueIndex;
-    public int dequeueIndex;
-
-    public SimpleQueue(int size)
-    {
-        data = new T[size];
-        enqueueIndex = 0;
-        dequeueIndex = 0;
-    }
-
-    public bool TryEnqueue(T item)
-    {
-        if (enqueueIndex >= data.Length)
-        {
-            return false;
-        }
-
-        data[enqueueIndex] = item;
-        //very important, because if we write the index before the data, the consumer could read try to read null data
-        Volatile.Write(ref enqueueIndex, enqueueIndex + 1);
-        return true;
-    }
-
-    public bool TryDequeue(out T item)
-    {
-        if (dequeueIndex >= enqueueIndex)
-        {
-            item = default!;
-            return false;
-        }
-
-        item = data[dequeueIndex++];
-        data[dequeueIndex - 1] = default!;
-        return true;
-    }
-}
 
 public class UnorderedThreadSafeQueue<T>
 {
-    private const int Size = 128;
-    private SimpleQueue<T> _queueA = new(Size);
-    private SimpleQueue<T> _queueB = new(Size);
+    private ConcurrentQueue<T> _queue = new();
+
+    public UnorderedThreadSafeQueue()
+    {
+        for (var i = 0; i < 1024; i++)
+        {
+            _queue.Enqueue(default!);
+        }
+
+        for (var i = 0; i < 1024; i++)
+        {
+            _queue.TryDequeue(out _);
+        }
+    }
 
     internal bool TryDequeue(out T item)
     {
-        var res = _queueB.TryDequeue(out item);
-        if (!res && _queueA.enqueueIndex > 0)
-        {
-            SwapBuffers();
-            return _queueB.TryDequeue(out item);
-        }
-
-        return res;
+        return _queue.TryDequeue(out item);
     }
 
     internal bool TryEnqueue(T item)
     {
-        return _queueA.TryEnqueue(item);
-    }
-
-    private void SwapBuffers()
-    {
-        Volatile.Write(ref _queueB.enqueueIndex, 0);
-        Volatile.Write(ref _queueA.dequeueIndex, 0);
-        (_queueA, _queueB) = (_queueB, _queueA);
+        _queue.Enqueue(item);
+        return true;
     }
 }

--- a/JobScheduler/Utils/UnorderedQueue.cs
+++ b/JobScheduler/Utils/UnorderedQueue.cs
@@ -1,0 +1,72 @@
+namespace Schedulers.Utils;
+
+public class SimpleQueue<T>
+{
+    public T[] data;
+    public int enqueueIndex;
+    public int dequeueIndex;
+
+    public SimpleQueue(int size)
+    {
+        data = new T[size];
+        enqueueIndex = 0;
+        dequeueIndex = 0;
+    }
+
+    public bool TryEnqueue(T item)
+    {
+        if (enqueueIndex >= data.Length)
+        {
+            return false;
+        }
+
+        data[enqueueIndex] = item;
+        //very important, because if we write the index before the data, the consumer could read try to read null data
+        Volatile.Write(ref enqueueIndex, enqueueIndex + 1);
+        return true;
+    }
+
+    public bool TryDequeue(out T item)
+    {
+        if (dequeueIndex >= enqueueIndex)
+        {
+            item = default!;
+            return false;
+        }
+
+        item = data[dequeueIndex++];
+        data[dequeueIndex - 1] = default!;
+        return true;
+    }
+}
+
+public class UnorderedThreadSafeQueue<T>
+{
+    private const int Size = 128;
+    private SimpleQueue<T> _queueA = new(Size);
+    private SimpleQueue<T> _queueB = new(Size);
+
+    internal bool TryDequeue(out T item)
+    {
+        var res = _queueB.TryDequeue(out item);
+        if (!res && _queueA.enqueueIndex > 0)
+        {
+            SwapBuffers();
+            return _queueB.TryDequeue(out item);
+        }
+
+        return res;
+    }
+
+    internal bool TryEnqueue(T item)
+    {
+        return _queueA.TryEnqueue(item);
+    }
+
+    private void SwapBuffers()
+    {
+        Volatile.Write(ref _queueB.enqueueIndex, 0);
+        Volatile.Write(ref _queueA.dequeueIndex, 0);
+        (_queueA, _queueB) = (_queueB, _queueA);
+    }
+}

--- a/JobScheduler/Utils/WorkStealingQueue.cs
+++ b/JobScheduler/Utils/WorkStealingQueue.cs
@@ -251,4 +251,9 @@ internal class WorkStealingDeque<T>
         item = stolen;
         return true;
     }
+
+    public int Size()
+    {
+        return (int)(Volatile.Read(ref _bottom) - Interlocked.Read(ref _top));
+    }
 }


### PR DESCRIPTION
Changes: 
Fix deadlock by using new queue type
Add a method to avoid creating handles arrays by tracking them using "generations"(probably should be done using a parent job or something).
Change benchmarks to showcase somewhat heavier job.